### PR TITLE
33062 Adds a call to log a user metric for the DCC version

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -89,3 +89,5 @@ description: "Shotgun Integration in Flame"
 requires_shotgun_version:
 requires_core_version: "v0.14.76"
 
+# XXX will require core version with metrics logging
+

--- a/info.yml
+++ b/info.yml
@@ -89,5 +89,3 @@ description: "Shotgun Integration in Flame"
 requires_shotgun_version:
 requires_core_version: "v0.14.76"
 
-# XXX will require core version with metrics logging
-

--- a/python/startup/app_launcher.py
+++ b/python/startup/app_launcher.py
@@ -102,6 +102,8 @@ def launch_flame(dcc_path, dcc_args):
     cmd_line = "\"%s\" %s %s &" % (dcc_path, app_args, " ".join(dcc_args))
     flame_engine.log_debug("Full command line '%s'" % cmd_line)
     flame_engine.log_debug("-" * 60)
+
+    flame_engine.log_user_attribute_metric("Flame version", full_version_str)
     
     return os.system(cmd_line)
     

--- a/python/startup/app_launcher.py
+++ b/python/startup/app_launcher.py
@@ -103,7 +103,11 @@ def launch_flame(dcc_path, dcc_args):
     flame_engine.log_debug("Full command line '%s'" % cmd_line)
     flame_engine.log_debug("-" * 60)
 
-    flame_engine.log_user_attribute_metric("Flame version", full_version_str)
+    try:
+        flame_engine.log_user_attribute_metric("Flame version", full_version_str)
+    except:
+        # ignore all errors. ex: using a core that doesn't support metrics
+        pass
     
     return os.system(cmd_line)
     


### PR DESCRIPTION
The call logs the metric internally and ignores any errors. This prevents the need to force the engine's users to update to a new core that supports metrics. When a supported core is updated, the metric will be logged.