### PR TITLE
Avoid crashing when starting a Flame project without Shotgun

### DIFF
--- a/flame_hooks/sg_batch_hook.py
+++ b/flame_hooks/sg_batch_hook.py
@@ -9,7 +9,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 # Note! This file implements the batchHook interface from Flame 2015.2
-
 def batchSetupLoaded(setupPath):
     """
     Hook called when a batch setup is loaded.
@@ -18,6 +17,12 @@ def batchSetupLoaded(setupPath):
     """
     import sgtk
     engine = sgtk.platform.current_engine()
+    
+    # We can't do anything without the Shotgun engine. 
+    # The engine is None when the user decides to not use the plugin for the project.
+    if engine is None:
+        return
+
     engine.trigger_batch_callback("batchSetupLoaded", {"setupPath": setupPath})        
 
 def batchSetupSaved(setupPath):
@@ -28,6 +33,12 @@ def batchSetupSaved(setupPath):
     """
     import sgtk
     engine = sgtk.platform.current_engine()
+
+    # We can't do anything without the Shotgun engine. 
+    # The engine is None when the user decides to not use the plugin for the project.
+    if engine is None:
+        return
+
     engine.trigger_batch_callback("batchSetupSaved", {"setupPath": setupPath})        
 
 def batchExportBegin(info, userData):
@@ -66,6 +77,12 @@ def batchExportBegin(info, userData):
     """
     import sgtk
     engine = sgtk.platform.current_engine()
+
+    # We can't do anything without the Shotgun engine. 
+    # The engine is None when the user decides to not use the plugin for the project.
+    if engine is None:
+        return
+
     engine.trigger_batch_callback("batchExportBegin", info)        
 
 def batchExportEnd(info, userData):
@@ -105,5 +122,10 @@ def batchExportEnd(info, userData):
     """
     import sgtk
     engine = sgtk.platform.current_engine()
-    engine.trigger_batch_callback("batchExportEnd", info)        
 
+    # We can't do anything without the Shotgun engine. 
+    # The engine is None when the user decides to not use the plugin for the project.
+    if engine is None:
+        return
+
+    engine.trigger_batch_callback("batchExportEnd", info)        

--- a/flame_hooks/sg_export_hook.py
+++ b/flame_hooks/sg_export_hook.py
@@ -9,7 +9,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 # Note! This file implements the exportHook interface from Flame 2015.2
-
 def getCustomExportProfiles(profiles):
     """
     Hook returning the custom export profiles to display to the user in the
@@ -20,7 +19,12 @@ def getCustomExportProfiles(profiles):
     """
     import sgtk
     engine = sgtk.platform.current_engine()
-    
+
+    # We can't do anything without the Shotgun engine. 
+    # The engine is None when the user decides to not use the plugin for the project.
+    if engine is None:
+        return
+
     for preset_title in engine.get_export_presets(): 
         profiles[preset_title] = {"preset_title": preset_title}
 
@@ -45,6 +49,11 @@ def preCustomExport(info, userData):
     # first, get the toolkit engine
     import sgtk
     engine = sgtk.platform.current_engine()
+
+    # We can't do anything without the Shotgun engine. 
+    # The engine is None when the user decides to not use the plugin for the project.
+    if engine is None:
+        return
 
     # get the preset that the user selected from the menu
     current_preset = userData.get("preset_title")
@@ -77,6 +86,11 @@ def postCustomExport(info, userData):
     import sgtk
     engine = sgtk.platform.current_engine()
 
+    # We can't do anything without the Shotgun engine. 
+    # The engine is None when the user decides to not use the plugin for the project.
+    if engine is None:
+        return
+
     # check if there is a toolkit export session currently 
     # progressing - in that case dispatch it to the appropriate app
     session_id = userData.get("session_id")
@@ -102,6 +116,11 @@ def preExport(info, userData):
     import sgtk
     engine = sgtk.platform.current_engine()
 
+    # We can't do anything without the Shotgun engine. 
+    # The engine is None when the user decides to not use the plugin for the project.
+    if engine is None:
+        return
+
     # check if there is a toolkit export session currently 
     # progressing - in that case dispatch it to the appropriate app
     session_id = userData.get("session_id")
@@ -125,6 +144,11 @@ def postExport(info, userData):
     # first, get the toolkit engine
     import sgtk
     engine = sgtk.platform.current_engine()
+
+    # We can't do anything without the Shotgun engine. 
+    # The engine is None when the user decides to not use the plugin for the project.
+    if engine is None:
+        return
 
     # check if there is a toolkit export session currently 
     # progressing - in that case dispatch it to the appropriate app
@@ -158,6 +182,11 @@ def preExportSequence(info, userData):
     import sgtk
     engine = sgtk.platform.current_engine()
 
+    # We can't do anything without the Shotgun engine. 
+    # The engine is None when the user decides to not use the plugin for the project.
+    if engine is None:
+        return
+
     # check if there is a toolkit export session currently 
     # progressing - in that case dispatch it to the appropriate app
     session_id = userData.get("session_id")
@@ -183,6 +212,11 @@ def postExportSequence(info, userData):
     # first, get the toolkit engine
     import sgtk
     engine = sgtk.platform.current_engine()
+
+    # We can't do anything without the Shotgun engine. 
+    # The engine is None when the user decides to not use the plugin for the project.
+    if engine is None:
+        return
 
     # check if there is a toolkit export session currently 
     # progressing - in that case dispatch it to the appropriate app
@@ -231,6 +265,11 @@ def preExportAsset(info, userData):
     # first, get the toolkit engine
     import sgtk
     engine = sgtk.platform.current_engine()
+
+    # We can't do anything without the Shotgun engine. 
+    # The engine is None when the user decides to not use the plugin for the project.
+    if engine is None:
+        return
 
     # check if there is a toolkit export session currently 
     # progressing - in that case dispatch it to the appropriate app
@@ -282,6 +321,11 @@ def postExportAsset(info, userData):
     # first, get the toolkit engine
     import sgtk
     engine = sgtk.platform.current_engine()
+
+    # We can't do anything without the Shotgun engine. 
+    # The engine is None when the user decides to not use the plugin for the project.
+    if engine is None:
+        return
 
     # check if there is a toolkit export session currently 
     # progressing - in that case dispatch it to the appropriate app

--- a/flame_hooks/sg_hook.py
+++ b/flame_hooks/sg_hook.py
@@ -9,8 +9,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 # Note! This file implements the hook interface from Flame 2016.1
-
-
 def getCustomUIActions():
     """
     Hook returning the custom ui actions to display to the user in the contextual menu.
@@ -50,6 +48,12 @@ def getCustomUIActions():
     import sgtk
     engine = sgtk.platform.current_engine()
 
+    # We can't do anything without the Shotgun engine. 
+    # The engine is None when the user decides to not use the plugin for the project.
+    if engine is None:
+        return ()
+
+    
     # build a list of the matching commands
     # returns a list of items, each a tuple with (instance_name, name, callback)
     context_commands = engine._get_commands_matching_setting("context_menu")
@@ -94,6 +98,12 @@ def customUIAction(info, userData):
     # first, get the toolkit engine
     import sgtk
     engine = sgtk.platform.current_engine()
+
+    # We can't do anything without the Shotgun engine. 
+    # The engine is None when the user decides to not use the plugin for the project.
+    if engine is None:
+        return
+
     # get the comand name
     command_name = info["name"]
     # find it in toolkit

--- a/flame_hooks/sg_project_hook.py
+++ b/flame_hooks/sg_project_hook.py
@@ -38,8 +38,15 @@ def appInitialized(projectName):
     
     else:
         # no engine running - so start one!
-        engine_name = os.environ.get("TOOLKIT_ENGINE_NAME") 
-        context = sgtk.context.deserialize(os.environ.get("TOOLKIT_CONTEXT"))
+        engine_name = os.environ.get("TOOLKIT_ENGINE_NAME")
+        toolkit_context = os.environ.get("TOOLKIT_CONTEXT")
+        
+        if toolkit_context is None:
+            logger = sgtk.LogManager.get_logger(__name__)
+            logger.debug("No toolkit context, can't initialize the engine")
+            return
+        
+        context = sgtk.context.deserialize(toolkit_context)
         
         # set a special environment variable to help hint to the engine
         # that we are running a backburner job


### PR DESCRIPTION
Now the tk-flame won't crash if someone starts a project without the shotgun integration and flame hooks that use the engine is triggered.
