### PR TITLE
Don't show project switching warning when running from toolkit

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -276,7 +276,7 @@ class FlameEngine(sgtk.platform.Engine):
         Called when the engine is being destroyed
         """
         self.log_debug("%s: Destroying..." % self)
-    
+
     @property
     def python_executable(self):
         """

--- a/flame_hooks/sg_project_hook.py
+++ b/flame_hooks/sg_project_hook.py
@@ -21,20 +21,24 @@ def appInitialized(projectName):
     
     import sgtk
     import os    
-    
-    if sgtk.platform.current_engine():
+
+    engine = sgtk.platform.current_engine()
+
+    if engine:
         # there is already an engine running.
         # TODO: later on, allow for switching of engines as projects 
         #       are being switched. For now, issue a warning
         
         # Note - Since Flame is a PySide only environment, we import it directly
         # rather than going through the sgtk wrappers. 
-        from PySide import QtGui     
-        QtGui.QMessageBox.warning(None,
-                                  "No project switching!",
-                                  "The Shotgun integration does not currently support project switching.\n"
-                                  "Even if you switch projects, any Shotgun specific configuration will\n"
-                                  "remain connected to the initially loaded project.")
+
+        if engine.get_setting("project_switching") is False:
+            from PySide import QtGui
+            QtGui.QMessageBox.warning(None,
+                                      "No project switching!",
+                                      "The Shotgun integration does not currently support project switching.\n"
+                                      "Even if you switch projects, any Shotgun specific configuration will\n"
+                                      "remain connected to the initially loaded project.")
     
     else:
         # no engine running - so start one!

--- a/info.yml
+++ b/info.yml
@@ -17,7 +17,12 @@ configuration:
         type: bool
         description: Controls whether debug messages should be emitted to the logger
         default_value: false
-        
+
+    project_switching:
+        type: bool
+        description: Hint about the possibility to switch project
+        default_value: false
+
     project_startup_hook:
         type: hook
         default_value: "{self}/project_startup.py"


### PR DESCRIPTION
Project switching is supported in the TAAP so we should not display the 'No project switching!' warning.
