### PR TITLE
Add env var about what is running

### DIFF
--- a/python/startup/app_launcher.py
+++ b/python/startup/app_launcher.py
@@ -107,6 +107,9 @@ def launch_flame(dcc_path, dcc_args):
     flame_engine.log_debug("Full command line '%s'" % cmd_line)
     flame_engine.log_debug("-" * 60)
 
+    # keep a hint about the current workflow
+    os.environ["SHOTGUN_FLAME_INTEGRATION"] = "CLASSIC"
+    
     return os.system(cmd_line)
     
 


### PR DESCRIPTION
https://jira.autodesk.com/browse/SMOK-41973

This add a hint that notify that we are running from the classic integration.

This is linked to https://github.com/shotgunsoftware/tk-plugin-flame/pull/9