### PR TITLE
Set HOME env var in backburner.py so the toolkit engine doesn't try t…

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -904,7 +904,8 @@ class FlameEngine(sgtk.platform.Engine):
         data["method_to_execute"] = method_name
         data["args"] = args
         data["sgtk_core_location"] = os.path.dirname(sgtk.__path__[0])
-        
+        data["user_home_path"] = os.path.expanduser( "~" )
+
         fh = open(session_file, "wb")
         pickle.dump(data, fh)
         fh.close()

--- a/python/startup/backburner.py
+++ b/python/startup/backburner.py
@@ -48,6 +48,10 @@ engine_instance = data["engine_instance"]
 app_instance = data["app_instance"]
 method_to_execute = data["method_to_execute"]
 method_args = data["args"]
+user_home_path = data["user_home_path"]
+
+# fix home path environment not set by backburner
+os.environ["HOME"] = user_home_path
 
 # add sgtk to our python path
 sys.path.append(sgtk_core_location)

--- a/python/startup/backburner.py
+++ b/python/startup/backburner.py
@@ -50,7 +50,16 @@ method_to_execute = data["method_to_execute"]
 method_args = data["args"]
 user_home_path = data["user_home_path"]
 
-# fix home path environment not set by backburner
+# FIXME :
+#         The problem :
+#         -At the time this is written, backburner is running with a root environment and
+#         with variable user id permissions which is a setting when creating the job. (cmdjob -userRights)
+#         This cause a problem when we call os.path.expanduser when building the logger path
+#         which depends on the environment. The task failed when trying to access root
+#         directories with another user permissions.
+#         The solution :
+#         -Set the HOME variable environment manualy.
+#         -Long term, backburner should set a proper environment and this could be removed.
 os.environ["HOME"] = user_home_path
 
 # add sgtk to our python path


### PR DESCRIPTION
…o access root directory.