### PR TITLE
Avoid error if the custom command is not implemented in flame engine

### DIFF
--- a/flame_hooks/sg_hook.py
+++ b/flame_hooks/sg_hook.py
@@ -117,8 +117,8 @@ def customUIAction(info, userData):
     # get the comand name
     command_name = info["name"]
     # find it in toolkit
-    command_obj = engine.commands[command_name] if command_name in engine.commands else None
+    command_obj = engine.commands.get(command_name)
 
     # execute the callback if found
-    if command_obj is not None:
+    if command_obj:
         command_obj["callback"]()

--- a/flame_hooks/sg_hook.py
+++ b/flame_hooks/sg_hook.py
@@ -117,6 +117,8 @@ def customUIAction(info, userData):
     # get the comand name
     command_name = info["name"]
     # find it in toolkit
-    command_obj = engine.commands[command_name]
-    # execute the callback
-    command_obj["callback"]()
+    command_obj = engine.commands[command_name] if command_name in engine.commands else None
+
+    # execute the callback if found
+    if command_obj is not None:
+        command_obj["callback"]()


### PR DESCRIPTION
This is for the case where a custom UI action from another python hook directory is called and the flame engine didn't have any callback for it.