### PR TITLE
SMOK-42791 | Sorted custom UI Action

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -538,17 +538,7 @@ class FlameEngine(sgtk.platform.Engine):
         if not commands:
             return ()
 
-        actions = []
-
-        # Add the command to the action list if present in the commands list
-        if "Shotgun Panel..." in commands:
-            actions += [{"name": "Shotgun Panel...", "caption": "Shotgun Panel"}]
-
-        if "Launch Shotgun in Web Browser" in commands:
-            actions += [{"name": "Launch Shotgun in Web Browser", "caption": "Jump to Shotgun"}]
-
-        if "Log Out" in commands:
-            actions += [{"name": "Log Out", "caption": "Log Out"}]
+        actions = self._generate_actions_list(commands)
 
         if actions:
             return (
@@ -559,6 +549,43 @@ class FlameEngine(sgtk.platform.Engine):
             )
         else:
             return ()
+
+    @property
+    def ui_command_list(self):
+        """
+        Ordered list of UI command tuples where the first element is the registered command name and the second one is
+        the display name in the Flame UI.
+
+        :return: List of ordered Strings tuple
+        """
+        return [("Shotgun Panel...", "Shotgun Panel"),
+                ("Launch Shotgun in Web Browser", "Jump to Shotgun"),
+                ("Log Out", "Log Out")]
+
+    def _generate_actions_list(self, registered_commands):
+        """
+        Generate a list of UI commands based on the ordered ui_command_list. The generated list will respect the
+        ui_command_list order and will add to the end every command not in the ui_command_list.
+
+        :param registered_commands: list of commands registered in the engine
+        :return:
+        """
+        logger = sgtk.LogManager.get_logger(__name__)
+        actions = []
+
+        # Add the ui_command in the list if the command is registered in the engine
+        for ui_command in self.ui_command_list:
+            if ui_command[0] in registered_commands:
+                actions += [{"name": ui_command[0], "caption": ui_command[1]}]
+
+        # Add registered command that is not in the ui_command_list
+        known_commands = [command[0] for command in self.ui_command_list]
+        for command_name in registered_commands:
+            if command_name not in known_commands:
+                logger.debug("[%s] is not in the ui_command_list. It will be added at the end of the list." % command_name)
+                actions += [{"name": command_name, "caption": command_name}]
+
+        return actions
 
     ################################################################################################################
     # Engine Bootstrap

--- a/engine.py
+++ b/engine.py
@@ -562,12 +562,12 @@ class FlameEngine(sgtk.platform.Engine):
                 ("Launch Shotgun in Web Browser", "Jump to Shotgun"),
                 ("Log Out", "Log Out")]
 
-    def _generate_actions_list(self, registered_commands):
+    def _generate_actions_list(self, registered_command_names):
         """
         Generate a list of UI commands based on the ordered ui_command_list. The generated list will respect the
         ui_command_list order and will add to the end every command not in the ui_command_list.
 
-        :param registered_commands: list of commands registered in the engine
+        :param registered_command_names: list of commands registered in the engine
         :return:
         """
         logger = sgtk.LogManager.get_logger(__name__)
@@ -575,15 +575,16 @@ class FlameEngine(sgtk.platform.Engine):
 
         # Add the ui_command in the list if the command is registered in the engine
         for ui_command in self.ui_command_list:
-            if ui_command[0] in registered_commands:
-                actions += [{"name": ui_command[0], "caption": ui_command[1]}]
+            if ui_command[0] in registered_command_names:
+                actions += [{"name": ui_command[0],  # Registered command in the engine
+                             "caption": ui_command[1]}]  # Name of the command in the UI
 
         # Add registered command that is not in the ui_command_list
-        known_commands = [command[0] for command in self.ui_command_list]
-        for command_name in registered_commands:
-            if command_name not in known_commands:
-                logger.debug("[%s] is not in the ui_command_list. It will be added at the end of the list." % command_name)
-                actions += [{"name": command_name, "caption": command_name}]
+        ui_command_names = [ui_command[0] for ui_command in self.ui_command_list]
+        for registered_command_name in registered_command_names:
+            if registered_command_name not in ui_command_names:
+                logger.debug("[%s] is not in the ui_command_list. It will be added at the end of the list." % registered_command_name)
+                actions += [{"name": registered_command_name, "caption": registered_command_name}]
 
         return actions
 

--- a/engine.py
+++ b/engine.py
@@ -512,6 +512,53 @@ class FlameEngine(sgtk.platform.Engine):
         """        
         logging.getLogger(LOG_CHANNEL).error(msg)
 
+    @property
+    def enabled_ui_action(self):
+        """
+        Provide a ordered Custom UI action tuple based on the registered commands and the design
+
+        :returns: Custom UI action tuple
+        """
+        # build a list of the matching commands
+        # returns a list of items, each a tuple with (instance_name, name, callback)
+        context_commands = self._get_commands_matching_setting("context_menu")
+
+        # Commands are uniquely identified by name so build a list of them
+        commands = []
+        for (instance_name, command_name, callback) in context_commands:
+            commands.append(command_name)
+
+        # now add any 'normal' registered commands not already in the actions dict
+        # omit system actions that are on the context menu
+        for command_name in self.commands:
+            properties = self.commands[command_name]["properties"]
+            if command_name not in commands and properties.get("type") != "context_menu":
+                commands.append(command_name)
+
+        if not commands:
+            return ()
+
+        actions = []
+
+        # Add the command to the action list if present in the commands list
+        if "Shotgun Panel..." in commands:
+            actions += [{"name": "Shotgun Panel...", "caption": "Shotgun Panel"}]
+
+        if "Launch Shotgun in Web Browser" in commands:
+            actions += [{"name": "Launch Shotgun in Web Browser", "caption": "Jump to Shotgun"}]
+
+        if "Log Out" in commands:
+            actions += [{"name": "Log Out", "caption": "Log Out"}]
+
+        if actions:
+            return (
+                {
+                    "name": "Shotgun",
+                    "actions": tuple(actions)
+                },
+            )
+        else:
+            return ()
 
     ################################################################################################################
     # Engine Bootstrap

--- a/flame_hooks/sg_hook.py
+++ b/flame_hooks/sg_hook.py
@@ -63,36 +63,7 @@ def getMainMenuCustomUIActions( ):
     if engine is None:
         return ()
 
-    
-    # build a list of the matching commands
-    # returns a list of items, each a tuple with (instance_name, name, callback)
-    context_commands = engine._get_commands_matching_setting("context_menu")
-
-    # Commands are uniquely identified by name so build a list of them
-    commands = []
-    for (instance_name, command_name, callback) in context_commands:
-        commands.append(command_name)
-
-    # now add any 'normal' registered commands not already in the actions dict
-    # omit system actions that are on the context menu
-    for command_name in engine.commands:
-        properties = engine.commands[command_name]["properties"]
-        if command_name not in commands and properties.get("type") != "context_menu":
-            commands.append(command_name)
-
-    # do not add the menu if there are no matches
-    if not commands:
-        return ()
-
-    # generate flame data structure
-    actions = [{"name": x, "caption": x} for x in commands]
-
-    return (
-        {
-            "name": "Shotgun",
-            "actions": tuple(actions)
-        },
-    )
+    return engine.enabled_ui_action
 
 
 def customUIAction(info, userData):


### PR DESCRIPTION
This is for: [SMOK-42791](https://jira.autodesk.com/browse/SMOK-42791)

Since the commands is stored in a dictionary, we need to manually sort the actions.

More information: 
Currently in Flame, the Main menu have a Shotgun sub menu. This submenu have a list of commands registered in the tk-flame engine. The problem is that when we query the engine for the list of commands, we don't have the concept of order since these commands are stored in a dictionary. This is why I added a sorted list of commands in the tk-flame to be able to ask for an ordered command list for the customUIaction hook.

This is for finally have 
>Shotgun Panel
>Jump to Shotgun
>Logout

Instead of 
>Log Out (added in tk-plugin-flame)
>Launch Shotgun in Web Browser (added in tk-plugin-flame)
>Shotgun Panel... (added in tk-multi-shotgunpanel)

Only by adding a value to a list of tuple in the tk-flame engine code.