### PR TITLE
SMOK-42978 | Add a Wiretap Central version check

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -948,7 +948,7 @@ class FlameEngine(sgtk.platform.Engine):
 
     def __get_wiretap_central_binary(self, binary_name):
         """
-        Try to returns the path to a binary in the wiretap central binary collection.
+        Try to returns the path to a binary in the Wiretap Central binary collection.
 
         This function is compatible with both new Wiretap Central and the legacy Wiretap Central.
 
@@ -957,7 +957,7 @@ class FlameEngine(sgtk.platform.Engine):
         """
         # Wiretap Central can only be present on MacOS and on Linux
         if sys.platform not in ["darwin", "linux2"]:
-            raise TankError("Your operating system does not support wiretap central!")
+            raise TankError("Your operating system does not support Wiretap Central!")
 
         # Priority have to be given to every ".bin" executable on the Wiretap Central binary folder
         wtc_path = self._get_wiretap_central_bin_path()


### PR DESCRIPTION
This adds support for the new version of Wiretap Central. Instead of using the major version number, we are looking for the wiretap binaries using a predefined priority.

1. We check in the new Wiretap Central bin folder for the binary name ending with a ".bin"
(To use some binaries, you need to use the .bin version on the binary)
2. We check in the new Wiretap Central bin folder for the binary without the ".bin" 
(If the ".bin" don't exist it's because we can use the binary like in the legacy version)
3. We check in the legacy Wiretap Central bin folder for the binary without the ".bin"
(Like before) 