### PR TITLE
SMOK-42791 | Reorder and rename customUIActions elements

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -207,22 +207,27 @@ class FlameEngine(sgtk.platform.Engine):
     def _get_commands_matching_setting(self, setting):
         """
         This expects a list of dictionaries in the form:
-            {name: command-name, app_instance: instance-name }
+            {name: "command-name", app_instance: "instance-name", display_name: "Display Name"  }
 
         The app_instance value will match a particular app instance associated with
-        the engine.  The name is the menu name of the command to run when the engine starts up.
+        the engine. The name is the menu name of the command to run when the engine starts up. The
+        display_name is the menu display name of the command to run.
+
         If name is '' then all commands from the given app instance are returned.
+        If display_name is not present, name will be used instead.
 
         :returns A list of tuples for all commands that match the given setting.
-                 Each tuple will be in the form (instance_name, command_name, callback)
+                 Each tuple will be in the form (instance_name, display_name, command_name, callback)
         """
         # return a dictionary grouping all the commands by instance name
         commands_by_instance = {}
         for (name, value) in self.commands.iteritems():
             app_instance = value["properties"].get("app")
-            if app_instance is None:
-                continue
-            instance_name = app_instance.instance_name
+            if app_instance:
+                instance_name = app_instance.instance_name
+            else:
+                instance_name = "null"
+
             commands_by_instance.setdefault(instance_name, []).append((name, value["callback"]))
 
         # go through the values from the setting and return any matching commands
@@ -231,6 +236,7 @@ class FlameEngine(sgtk.platform.Engine):
         for command in setting_value:
             command_name = command["name"]
             instance_name = command["app_instance"]
+            display_name = command.get("display_name", command_name)
             instance_commands = commands_by_instance.get(instance_name)
 
             if instance_commands is None:
@@ -243,7 +249,7 @@ class FlameEngine(sgtk.platform.Engine):
             for (name, callback) in instance_commands:
                 # add the command if the name from the settings is '' or the name matches
                 if not command_name or (command_name == name):
-                    ret_value.append((instance_name, name, callback))
+                    ret_value.append((instance_name, display_name, name, callback))
 
         return ret_value
 

--- a/engine.py
+++ b/engine.py
@@ -226,7 +226,9 @@ class FlameEngine(sgtk.platform.Engine):
             if app_instance:
                 instance_name = app_instance.instance_name
             else:
-                instance_name = "null"
+                # A command without an app instance in the context menu is actually coming from the engine, so we'll
+                # use the engine name instead.
+                instance_name = "tk-flame"
 
             commands_by_instance.setdefault(instance_name, []).append((name, value["callback"]))
 

--- a/flame_hooks/sg_hook.py
+++ b/flame_hooks/sg_hook.py
@@ -63,29 +63,31 @@ def getMainMenuCustomUIActions( ):
     if engine is None:
         return ()
 
-    
     # build a list of the matching commands
-    # returns a list of items, each a tuple with (instance_name, name, callback)
-    context_commands = engine._get_commands_matching_setting("context_menu")
+    # returns a list of items, each a tuple with (instance_name, display_name, name, callback)
+    commands = engine._get_commands_matching_setting("context_menu")
 
-    # Commands are uniquely identified by name so build a list of them
-    commands = []
-    for (instance_name, command_name, callback) in context_commands:
-        commands.append(command_name)
+    # Commands are uniquely identified by command name and by display name so build a list of them
+    context_commands = []
+    for (instance_name, display_name, command_name, callback) in commands:
+        context_commands.append((command_name, display_name))
+
+
 
     # now add any 'normal' registered commands not already in the actions dict
     # omit system actions that are on the context menu
-    for command_name in engine.commands:
-        properties = engine.commands[command_name]["properties"]
-        if command_name not in commands and properties.get("type") != "context_menu":
-            commands.append(command_name)
+    context_command_names = [context_command[0] for context_command in context_commands]
+    for engine_command_name in engine.commands:
+        properties = engine.commands[engine_command_name]["properties"]
+        if engine_command_name not in context_command_names and properties.get("type") != "context_menu":
+            context_commands.append((engine_command_name, engine_command_name))
 
     # do not add the menu if there are no matches
-    if not commands:
+    if not context_commands:
         return ()
 
     # generate flame data structure
-    actions = [{"name": x, "caption": x} for x in commands]
+    actions = [{"name": command_name, "caption": display_name} for (command_name, display_name) in context_commands]
 
     return (
         {

--- a/flame_hooks/sg_hook.py
+++ b/flame_hooks/sg_hook.py
@@ -80,6 +80,7 @@ def getMainMenuCustomUIActions( ):
     for engine_command_name in engine.commands:
         properties = engine.commands[engine_command_name]["properties"]
         if engine_command_name not in context_command_names and properties.get("type") != "context_menu":
+            context_command_names.append(engine_command_name)
             context_commands.append((engine_command_name, engine_command_name))
 
     # do not add the menu if there are no matches

--- a/info.yml
+++ b/info.yml
@@ -70,18 +70,20 @@ configuration:
     context_menu:
         type: list
         description: "Controls the commands that show up in Flame's context menu. This is a list
-                     where each element is a dictionary with two keys: 'app_instance' and 'name'.
+                     where each element is a dictionary with three keys: 'app_instance', 'name' and 'display_name'.
                      The app_instance value connects this entry to a particular app instance defined
-                     in the environment configuration file.  The name is the menu name of the
-                     command to run when flame starts up.  If name is '' then all commands from the
-                     given app instance are started."
-        allows_empty: True                     
+                     in the environment configuration file.  The name value is name of the registered command in the
+                     engine. The display_name value is the name that Flame should show in the menu.
+                     If name is '' then all commands from the given app instance are started.
+                     If display_name is not present, name will be used instead"
+        allows_empty: True
         default_value: []
         values:
             type: dict
             items:
                 name: { type: str }
                 app_instance: { type: str }
+               #display_name: { type: str } (optional)
 
 # the Shotgun fields that this engine needs in order to operate correctly
 requires_shotgun_fields:


### PR DESCRIPTION
This allows the user to specify an order to his registered commands. By doing this, we won't have the weird arbitrary order in the Shotgun submenu.

This will also allow to specify special (but optional to ensure backward compatibility) display_name to be able to specify what is the name that Flame should display.

From ![unordered](https://cloud.githubusercontent.com/assets/6785406/21159610/e1a88f38-c14f-11e6-8094-a46425980758.png) to ![ordered](https://cloud.githubusercontent.com/assets/6785406/21159613/e7eaa426-c14f-11e6-86f3-a267e19bc448.png)

Only by changing https://github.com/shotgunsoftware/tk-config-flameplugin/blob/master/env/project.yml#L73