### PR TITLE
SMOK-43033 | Ensure valid session before Backburner job

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -938,6 +938,9 @@ class FlameEngine(sgtk.platform.Engine):
         self.log_debug("App: %s" % app)
         self.log_debug("Method: %s with args %s" % (method_name, args))
 
+        # Make sure that the session is not expired
+        sgtk.get_authenticated_user().refresh_credentials()
+
         # kick it off        
         if os.system(full_cmd) != 0:
             raise TankError("Shotgun backburner job could not be created. Please see log for details.")


### PR DESCRIPTION
This makes sure that Backburner will not have to try to run a job with an expired session.