### PR TITLE
SMOK-43020 | Send job to backburner as the effective user

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -15,6 +15,7 @@ A Toolkit engine for Flame
 import os
 import pwd
 import grp
+import pipes
 import re
 import sys
 import uuid
@@ -955,7 +956,7 @@ class FlameEngine(sgtk.platform.Engine):
             e_group = grp.getgrgid(os.getegid()).gr_name
 
             # Run the command as the effective user
-            full_cmd = "sudo -g %s -u %s bash -c \'%s\'" % (e_group, e_user, full_cmd)
+            full_cmd = "sudo -g %s -u %s bash -c %s" % (e_group, e_user, pipes.quote(full_cmd))
             self.log_debug("Running root but will send the job as [%s] of the [%s] group" % (e_user, e_group))
 
         # Make sure that the session is not expired

--- a/engine.py
+++ b/engine.py
@@ -14,6 +14,7 @@ A Toolkit engine for Flame
 
 import os
 import pwd
+import grp
 import re
 import sys
 import uuid
@@ -951,10 +952,11 @@ class FlameEngine(sgtk.platform.Engine):
         if os.getuid() == 0:  # root
             # Getting the user name of the user who started Flame (the effective user)
             e_user = pwd.getpwuid(os.geteuid()).pw_name
+            e_group = grp.getgrgid(os.getegid()).gr_name
 
             # Run the command as the effective user
-            full_cmd = "sudo -u %s bash -c \'%s\'" % (e_user, full_cmd)
-            self.log_debug("Running root but will send the job as %s" % e_user)
+            full_cmd = "sudo -g %s -u %s bash -c \'%s\'" % (e_group, e_user, full_cmd)
+            self.log_debug("Running root but will send the job as [%s] of the [%s] group" % (e_user, e_group))
 
         # Make sure that the session is not expired
         sgtk.get_authenticated_user().refresh_credentials()

--- a/python/startup/backburner.py
+++ b/python/startup/backburner.py
@@ -49,19 +49,6 @@ app_instance = data["app_instance"]
 method_to_execute = data["method_to_execute"]
 method_args = data["args"]
 flame_version = data["flame_version"]
-user_home_path = data["user_home_path"]
-
-# FIXME :
-#         The problem :
-#         -At the time this is written, backburner is running with a root environment and
-#         with variable user id permissions which is a setting when creating the job. (cmdjob -userRights)
-#         This cause a problem when we call os.path.expanduser when building the logger path
-#         which depends on the environment. The task failed when trying to access root
-#         directories with another user permissions.
-#         The solution :
-#         -Set the HOME variable environment manualy.
-#         -Long term, backburner should set a proper environment and this could be removed.
-os.environ["HOME"] = user_home_path
 
 # add sgtk to our python path
 sys.path.append(sgtk_core_location)


### PR DESCRIPTION
This fix the FIXME in backburner.py.

When we are running a version Flame up to 2017. x. y, the python hooks are running as root. This implies that when we submit a job to Backburner using -userRight, he executes the job as root. If the root user of the workstation doesn't have read and write permissions on the submitter's home directory, we were hitting a permission error when the flame engine was trying to update the log file during the job execution.

The fix for this is to execute the command that add the job to backburner as the effective user when the real user is root. In our case, the effective user is the user who started Flame. By doing this, we don't need to tweak the HOME env var and we know that the user have enough permission to write to his home. 