### PR TITLE
SMOK-43068 | Catch potential AuthenticationCancelled exception

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -962,14 +962,12 @@ class FlameEngine(sgtk.platform.Engine):
         try:
             # Make sure that the session is not expired
             sgtk.get_authenticated_user().refresh_credentials()
-            valid_session = True
         except sgtk.authentication.AuthenticationCancelled:
             self.log_debug("User cancelled auth. No backburner job will be created.")
-            valid_session = False
-
-        # kick it off
-        if valid_session and os.system(full_cmd) != 0:
-            raise TankError("Shotgun backburner job could not be created. Please see log for details.")
+        else:
+            # kick it off
+            if os.system(full_cmd) != 0:
+                raise TankError("Shotgun backburner job could not be created. Please see log for details.")
 
 
     ################################################################################################################

--- a/engine.py
+++ b/engine.py
@@ -959,11 +959,16 @@ class FlameEngine(sgtk.platform.Engine):
             full_cmd = "sudo -g %s -u %s bash -c %s" % (e_group, e_user, pipes.quote(full_cmd))
             self.log_debug("Running root but will send the job as [%s] of the [%s] group" % (e_user, e_group))
 
-        # Make sure that the session is not expired
-        sgtk.get_authenticated_user().refresh_credentials()
+        try:
+            # Make sure that the session is not expired
+            sgtk.get_authenticated_user().refresh_credentials()
+            valid_session = True
+        except sgtk.authentication.AuthenticationCancelled:
+            self.log_debug("User cancelled auth. No backburner job will be created.")
+            valid_session = False
 
-        # kick it off        
-        if os.system(full_cmd) != 0:
+        # kick it off
+        if valid_session and os.system(full_cmd) != 0:
             raise TankError("Shotgun backburner job could not be created. Please see log for details.")
 
 


### PR DESCRIPTION
This is to avoid having a stack trace on login cancel on cases when the credential is expired and the authentication dialog is shown to the user.