### PR TITLE
SMOK-43020 | Ensure that the backburner job have a valid HOME 

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -962,14 +962,12 @@ class FlameEngine(sgtk.platform.Engine):
         try:
             # Make sure that the session is not expired
             sgtk.get_authenticated_user().refresh_credentials()
-            valid_session = True
         except sgtk.authentication.AuthenticationCancelled:
             self.log_debug("User cancelled auth. No backburner job will be created.")
-            valid_session = False
-
-        # kick it off
-        if valid_session and os.system(full_cmd) != 0:
-            raise TankError("Shotgun backburner job could not be created. Please see log for details.")
+        else:
+            # kick it off
+            if os.system(full_cmd) != 0:
+                raise TankError("Shotgun backburner job could not be created. Please see log for details.")
 
 
     ################################################################################################################

--- a/engine.py
+++ b/engine.py
@@ -936,7 +936,7 @@ class FlameEngine(sgtk.platform.Engine):
         data["args"] = args
         data["sgtk_core_location"] = os.path.dirname(sgtk.__path__[0])
         data["flame_version"] = self._flame_version
-
+        data["user_home"] = os.path.expanduser("~")
         fh = open(session_file, "wb")
         pickle.dump(data, fh)
         fh.close()

--- a/engine.py
+++ b/engine.py
@@ -959,11 +959,16 @@ class FlameEngine(sgtk.platform.Engine):
             full_cmd = "sudo -g %s -u %s bash -c %s" % (e_group, e_user, pipes.quote(full_cmd))
             self.log_debug("Running root but will send the job as [%s] of the [%s] group" % (e_user, e_group))
 
-        # Make sure that the session is not expired
-        sgtk.get_authenticated_user().refresh_credentials()
+        try:
+            # Make sure that the session is not expired
+            sgtk.get_authenticated_user().refresh_credentials()
+            valid_session = True
+        except sgtk.authentication.AuthenticationCancelled:
+            self.log_debug("User cancelled auth. No backburner job will be created.")
+            valid_session = False
 
-        # kick it off        
-        if os.system(full_cmd) != 0:
+        # kick it off
+        if valid_session and os.system(full_cmd) != 0:
             raise TankError("Shotgun backburner job could not be created. Please see log for details.")
 
 

--- a/python/startup/backburner.py
+++ b/python/startup/backburner.py
@@ -49,6 +49,10 @@ app_instance = data["app_instance"]
 method_to_execute = data["method_to_execute"]
 method_args = data["args"]
 flame_version = data["flame_version"]
+user_home = data["home"]
+
+# Make sure that the job is running with the good home
+os.environ["HOME"] = user_home
 
 # add sgtk to our python path
 sys.path.append(sgtk_core_location)


### PR DESCRIPTION
This fix the bug about the fact that sometime, the HOME environment variable is not set when the job is created from 2017x1 on certain workstation. 

It's a revert a revert of one of the changes #32 because some security policies are more strict than others and sometime we should just keep it simple.