### PR TITLE
Added setup directory and group selection in project creation UI.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -358,6 +358,20 @@ class FlameEngine(sgtk.platform.Engine):
                 "flame"
             )
 
+    @property
+    def wiretap_tools_root(self):
+        """
+        The location of wiretap tool
+
+        :returns: Path as string
+        """
+        return os.path.join(
+            self.install_root,
+            "wiretap",
+            "tools",
+            self.flame_version
+        )
+
     def is_version_less_than(self, version_str):
         """
         Compares the given version string with the current 

--- a/python/tk_flame/project_create_dialog.py
+++ b/python/tk_flame/project_create_dialog.py
@@ -260,7 +260,7 @@ class ProjectCreateDialog(QtGui.QWidget):
         """
         settings = {}
         
-        setup_dir = self.ui.setup_dir.text()
+        setup_dir = self.ui.setup_dir.text().strip()
         if setup_dir:
             settings["SetupDir"] = setup_dir
         settings["FrameWidth"] = self.ui.width.text()

--- a/python/tk_flame/project_create_dialog.py
+++ b/python/tk_flame/project_create_dialog.py
@@ -28,7 +28,10 @@ class ProjectCreateDialog(QtGui.QWidget):
                  default_volume_name, 
                  volume_names, 
                  host_name, 
+                 default_group_name,
+                 group_names,
                  project_settings):
+
         """
         Constructor
         
@@ -61,6 +64,7 @@ class ProjectCreateDialog(QtGui.QWidget):
         
         # populate fixed fields (the first tab)
         self.ui.project_name.setText(project_name)
+        self.ui.setup_dir.setPlaceholderText("<default>")
         self.ui.user_name.setText(user_name)
         if workspace_name:
             self.ui.workspace_name.setText(workspace_name)
@@ -73,7 +77,15 @@ class ProjectCreateDialog(QtGui.QWidget):
         # now select the default value in combo box
         idx = self.ui.volume.findText(default_volume_name)
         self.ui.volume.setCurrentIndex(idx)
-        
+
+        self.ui.group_name.addItems(group_names)
+        idx = self.ui.group_name.findText(default_group_name)
+        self.ui.group_name.setCurrentIndex(idx)
+
+        if self._engine.is_version_less_than("2018.1"):
+            self.ui.group_name_label.setVisible(False)
+            self.ui.group_name.setVisible(False)
+
         # populate the resolution tab
         self.__populate_resolution_tab(project_settings)
                 
@@ -217,6 +229,14 @@ class ProjectCreateDialog(QtGui.QWidget):
         :returns: volume as string
         """
         return str(self.ui.volume.currentText())
+
+    def get_group_name(self):
+        """
+        Returns the selected group
+        
+        :returns: group as string
+        """
+        return str(self.ui.group_name.currentText())
          
     def get_settings(self):
         """
@@ -240,6 +260,9 @@ class ProjectCreateDialog(QtGui.QWidget):
         """
         settings = {}
         
+        setup_dir = self.ui.setup_dir.text()
+        if setup_dir:
+            settings["SetupDir"] = setup_dir
         settings["FrameWidth"] = self.ui.width.text()
         settings["FrameHeight"] = self.ui.height.text()
         settings["FrameDepth"] = self.ui.depth.currentText()

--- a/python/tk_flame/ui/project_create_dialog.py
+++ b/python/tk_flame/ui/project_create_dialog.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'project_create_dialog.ui'
 #
-#      by: pyside-uic 0.2.15 running on PySide 1.2.2
+#      by: pyside-uic 0.2.13 running on PySide 1.2.2
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -11,7 +11,7 @@ from tank.platform.qt import QtCore, QtGui
 class Ui_ProjectCreateDialog(object):
     def setupUi(self, ProjectCreateDialog):
         ProjectCreateDialog.setObjectName("ProjectCreateDialog")
-        ProjectCreateDialog.resize(446, 496)
+        ProjectCreateDialog.resize(450, 514)
         ProjectCreateDialog.setStyleSheet("/* this is to force the combo box dropdowns to show all items rather than displaying only a few items and a scroll bar */\n"
 "QComboBox QListView {\n"
 "height: 100px;\n"
@@ -71,11 +71,11 @@ class Ui_ProjectCreateDialog(object):
         sizePolicy.setHeightForWidth(self.label_6.sizePolicy().hasHeightForWidth())
         self.label_6.setSizePolicy(sizePolicy)
         self.label_6.setObjectName("label_6")
-        self.formLayout_3.setWidget(2, QtGui.QFormLayout.LabelRole, self.label_6)
+        self.formLayout_3.setWidget(3, QtGui.QFormLayout.LabelRole, self.label_6)
         self.user_name = QtGui.QLabel(self.project_overview_tab)
         self.user_name.setWordWrap(False)
         self.user_name.setObjectName("user_name")
-        self.formLayout_3.setWidget(2, QtGui.QFormLayout.FieldRole, self.user_name)
+        self.formLayout_3.setWidget(3, QtGui.QFormLayout.FieldRole, self.user_name)
         self.label_19 = QtGui.QLabel(self.project_overview_tab)
         sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Preferred)
         sizePolicy.setHorizontalStretch(0)
@@ -83,11 +83,14 @@ class Ui_ProjectCreateDialog(object):
         sizePolicy.setHeightForWidth(self.label_19.sizePolicy().hasHeightForWidth())
         self.label_19.setSizePolicy(sizePolicy)
         self.label_19.setObjectName("label_19")
-        self.formLayout_3.setWidget(3, QtGui.QFormLayout.LabelRole, self.label_19)
+        self.formLayout_3.setWidget(4, QtGui.QFormLayout.LabelRole, self.label_19)
         self.host_name = QtGui.QLabel(self.project_overview_tab)
         self.host_name.setWordWrap(False)
         self.host_name.setObjectName("host_name")
-        self.formLayout_3.setWidget(3, QtGui.QFormLayout.FieldRole, self.host_name)
+        self.formLayout_3.setWidget(4, QtGui.QFormLayout.FieldRole, self.host_name)
+        self.label_4 = QtGui.QLabel(self.project_overview_tab)
+        self.label_4.setObjectName("label_4")
+        self.formLayout_3.setWidget(2, QtGui.QFormLayout.LabelRole, self.label_4)
         self.label_17 = QtGui.QLabel(self.project_overview_tab)
         sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Preferred)
         sizePolicy.setHorizontalStretch(0)
@@ -95,11 +98,20 @@ class Ui_ProjectCreateDialog(object):
         sizePolicy.setHeightForWidth(self.label_17.sizePolicy().hasHeightForWidth())
         self.label_17.setSizePolicy(sizePolicy)
         self.label_17.setObjectName("label_17")
-        self.formLayout_3.setWidget(4, QtGui.QFormLayout.LabelRole, self.label_17)
+        self.formLayout_3.setWidget(5, QtGui.QFormLayout.LabelRole, self.label_17)
         self.workspace_name = QtGui.QLabel(self.project_overview_tab)
         self.workspace_name.setWordWrap(False)
         self.workspace_name.setObjectName("workspace_name")
-        self.formLayout_3.setWidget(4, QtGui.QFormLayout.FieldRole, self.workspace_name)
+        self.formLayout_3.setWidget(5, QtGui.QFormLayout.FieldRole, self.workspace_name)
+        self.group_name_label = QtGui.QLabel(self.project_overview_tab)
+        self.group_name_label.setObjectName("group_name_label")
+        self.formLayout_3.setWidget(6, QtGui.QFormLayout.LabelRole, self.group_name_label)
+        self.group_name = QtGui.QComboBox(self.project_overview_tab)
+        self.group_name.setObjectName("group_name")
+        self.formLayout_3.setWidget(6, QtGui.QFormLayout.FieldRole, self.group_name)
+        self.setup_dir = QtGui.QLineEdit(self.project_overview_tab)
+        self.setup_dir.setObjectName("setup_dir")
+        self.formLayout_3.setWidget(2, QtGui.QFormLayout.FieldRole, self.setup_dir)
         self.tabWidget.addTab(self.project_overview_tab, "")
         self.resolution_tab = QtGui.QWidget()
         self.resolution_tab.setObjectName("resolution_tab")
@@ -173,6 +185,7 @@ class Ui_ProjectCreateDialog(object):
         self.depth = QtGui.QComboBox(self.resolution_tab)
         self.depth.setMaxVisibleItems(100)
         self.depth.setObjectName("depth")
+        self.depth.addItem("")
         self.depth.addItem("")
         self.depth.addItem("")
         self.depth.addItem("")
@@ -379,8 +392,10 @@ class Ui_ProjectCreateDialog(object):
         self.user_name.setText(QtGui.QApplication.translate("ProjectCreateDialog", "xxx", None, QtGui.QApplication.UnicodeUTF8))
         self.label_19.setText(QtGui.QApplication.translate("ProjectCreateDialog", "<b>Host</b>", None, QtGui.QApplication.UnicodeUTF8))
         self.host_name.setText(QtGui.QApplication.translate("ProjectCreateDialog", "xxx", None, QtGui.QApplication.UnicodeUTF8))
+        self.label_4.setText(QtGui.QApplication.translate("ProjectCreateDialog", "<b>Setup Directory</b>", None, QtGui.QApplication.UnicodeUTF8))
         self.label_17.setText(QtGui.QApplication.translate("ProjectCreateDialog", "<b>Workspace</b>", None, QtGui.QApplication.UnicodeUTF8))
         self.workspace_name.setText(QtGui.QApplication.translate("ProjectCreateDialog", "xxx", None, QtGui.QApplication.UnicodeUTF8))
+        self.group_name_label.setText(QtGui.QApplication.translate("ProjectCreateDialog", "<b>Group</b>", None, QtGui.QApplication.UnicodeUTF8))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.project_overview_tab), QtGui.QApplication.translate("ProjectCreateDialog", "Project Overview", None, QtGui.QApplication.UnicodeUTF8))
         self.label.setText(QtGui.QApplication.translate("ProjectCreateDialog", "Resolution", None, QtGui.QApplication.UnicodeUTF8))
         self.width.setPlaceholderText(QtGui.QApplication.translate("ProjectCreateDialog", "width", None, QtGui.QApplication.UnicodeUTF8))
@@ -402,11 +417,12 @@ class Ui_ProjectCreateDialog(object):
         self.frame_rate.setItemText(8, QtGui.QApplication.translate("ProjectCreateDialog", "59.94 fps NDF", None, QtGui.QApplication.UnicodeUTF8))
         self.frame_rate.setItemText(9, QtGui.QApplication.translate("ProjectCreateDialog", "60 fps", None, QtGui.QApplication.UnicodeUTF8))
         self.label_3.setText(QtGui.QApplication.translate("ProjectCreateDialog", "Depth", None, QtGui.QApplication.UnicodeUTF8))
-        self.depth.setItemText(0, QtGui.QApplication.translate("ProjectCreateDialog", "16-bit fp", None, QtGui.QApplication.UnicodeUTF8))
-        self.depth.setItemText(1, QtGui.QApplication.translate("ProjectCreateDialog", "12-bit", None, QtGui.QApplication.UnicodeUTF8))
-        self.depth.setItemText(2, QtGui.QApplication.translate("ProjectCreateDialog", "12-bit u", None, QtGui.QApplication.UnicodeUTF8))
-        self.depth.setItemText(3, QtGui.QApplication.translate("ProjectCreateDialog", "10-bit", None, QtGui.QApplication.UnicodeUTF8))
-        self.depth.setItemText(4, QtGui.QApplication.translate("ProjectCreateDialog", "8-bit", None, QtGui.QApplication.UnicodeUTF8))
+        self.depth.setItemText(0, QtGui.QApplication.translate("ProjectCreateDialog", "32-bit", None, QtGui.QApplication.UnicodeUTF8))
+        self.depth.setItemText(1, QtGui.QApplication.translate("ProjectCreateDialog", "16-bit fp", None, QtGui.QApplication.UnicodeUTF8))
+        self.depth.setItemText(2, QtGui.QApplication.translate("ProjectCreateDialog", "12-bit", None, QtGui.QApplication.UnicodeUTF8))
+        self.depth.setItemText(3, QtGui.QApplication.translate("ProjectCreateDialog", "12-bit u", None, QtGui.QApplication.UnicodeUTF8))
+        self.depth.setItemText(4, QtGui.QApplication.translate("ProjectCreateDialog", "10-bit", None, QtGui.QApplication.UnicodeUTF8))
+        self.depth.setItemText(5, QtGui.QApplication.translate("ProjectCreateDialog", "8-bit", None, QtGui.QApplication.UnicodeUTF8))
         self.label_10.setText(QtGui.QApplication.translate("ProjectCreateDialog", "Field Dominance", None, QtGui.QApplication.UnicodeUTF8))
         self.field_dominance.setItemText(0, QtGui.QApplication.translate("ProjectCreateDialog", "PROGRESSIVE", None, QtGui.QApplication.UnicodeUTF8))
         self.field_dominance.setItemText(1, QtGui.QApplication.translate("ProjectCreateDialog", "FIELD_1", None, QtGui.QApplication.UnicodeUTF8))

--- a/python/tk_flame/ui/resources_rc.py
+++ b/python/tk_flame/ui/resources_rc.py
@@ -2,7 +2,7 @@
 
 # Resource object code
 #
-#      by: The Resource Compiler for PySide (Qt v4.8.7)
+#      by: The Resource Compiler for PySide (Qt v4.8.5)
 #
 # WARNING! All changes made in this file will be lost!
 

--- a/python/tk_flame/wiretap.py
+++ b/python/tk_flame/wiretap.py
@@ -220,11 +220,11 @@ class WiretapHandler(object):
             else:
                 self._engine.log_debug("Project settings ui will be bypassed.")            
             # create the project : Using the command line tool here instead of the python API because we need root privileges to set the group id. 
-            import subprocess
+            import subprocess, os
             project_create_cmd = [
-                self._engine.wiretap_tools_root + "/wiretap_create_node",
+                os.path.join(self._engine.wiretap_tools_root, "wiretap_create_node"),
                 "-n",
-                "/volumes/" + volume_name,
+                os.path.join("/volumes", volume_name),
                 "-d",
                 project_name ]
 

--- a/python/tk_flame/wiretap.py
+++ b/python/tk_flame/wiretap.py
@@ -187,10 +187,11 @@ class WiretapHandler(object):
             
             # now check if we should pop up a ui where the user can tweak the default prefs
             if self._engine.execute_hook_method("project_startup_hook", "use_project_settings_ui"):
-
                 # at this point we don't have a QT application running, because we are still
                 # in the pre-DCC launch phase, so need to wrap our modal dialog call
                 # in a helper method which also creates a QApplication.
+
+                (group_name, groups) = self._get_groups()
                 (return_code, widget) = start_qt_app_and_show_modal("Create Flame Project", 
                                                                     self._engine, 
                                                                     ProjectCreateDialog,
@@ -200,6 +201,8 @@ class WiretapHandler(object):
                                                                     volume_name,
                                                                     volumes,
                                                                     host_name,
+                                                                    group_name,
+                                                                    groups,
                                                                     project_settings
                                                                     )
                 
@@ -212,17 +215,24 @@ class WiretapHandler(object):
                     project_settings[k] = v
                     
                 volume_name = widget.get_volume_name()
+                group_name = widget.get_group_name()
                 
             else:
                 self._engine.log_debug("Project settings ui will be bypassed.")            
-                        
-            # resolve this as an object
-            volume = WireTapNodeHandle(self._server, "/volumes/%s" % volume_name)
-            
-            # create the project
-            project_node = WireTapNodeHandle()
-            if not volume.createNode(project_name, "PROJECT", project_node):
-                raise WiretapError("Unable to create project %s: %s" %  (project_name, volume.lastError()))
+            # create the project : Using the command line tool here instead of the python API because we need root privileges to set the group id. 
+            import subprocess
+            project_create_cmd = [
+                self._engine.wiretap_tools_root + "/wiretap_create_node",
+                "-n",
+                "/volumes/" + volume_name,
+                "-d",
+                project_name ]
+
+            if not self._engine.is_version_less_than("2018.1"):
+                project_create_cmd.append("-g")
+                project_create_cmd.append(group_name)
+
+            subprocess.check_call(project_create_cmd)
  
             # create project settings
 
@@ -242,6 +252,7 @@ class WiretapHandler(object):
             
             xml += "<Description>%s</Description>"             % "Created by Shotgun Flame Integration %s" % self._engine.version
             
+            xml += self._append_setting_to_xml(project_settings, "SetupDir")
             xml += self._append_setting_to_xml(project_settings, "FrameWidth")
             xml += self._append_setting_to_xml(project_settings, "FrameHeight")
             xml += self._append_setting_to_xml(project_settings, "FrameDepth")
@@ -249,7 +260,7 @@ class WiretapHandler(object):
             xml += self._append_setting_to_xml(project_settings, "FrameRate")
             xml += self._append_setting_to_xml(project_settings, "ProxyEnable", stops_working_in="2016.1")            
             xml += self._append_setting_to_xml(project_settings, "FieldDominance")            
-            xml += self._append_setting_to_xml(project_settings, "VisualDepth", starts_working_in="2015.3")
+            xml += self._append_setting_to_xml(project_settings, "VisualDepth", starts_working_in="2015.3", stops_working_in="2018.0")
 
             # proxy settings
             xml += self._append_setting_to_xml(project_settings, "ProxyWidthHint")
@@ -272,13 +283,12 @@ class WiretapHandler(object):
 
     
             # Set the project meta data
+            project_node = WireTapNodeHandle(self._server, "/projects/" + project_name)
             if not project_node.setMetaData("XML", xml):
                 raise WiretapError("Error setting metadata for %s: %s" % (project_name, project_node.lastError()))
             
             self._engine.log_debug( "Project successfully created.")
-         
-         
-         
+
     def _append_setting_to_xml(self, project_settings, setting, starts_working_in=None, stops_working_in=None):
         """
         Generates xml for a parameter. May return an empty string if the xml
@@ -344,6 +354,24 @@ class WiretapHandler(object):
             volumes.append(node_name.c_str())
         
         return volumes
+
+    def _get_groups(self):
+        """
+        Return the list of group available for the current user and the current group.
+        
+        :returns: (default_group, groups)
+        """
+
+        import pwd, grp, os
+        # fetch all group which the user is a part of
+        user = pwd.getpwuid(os.geteuid()).pw_name                         # current user
+        groups = [g.gr_name for g in grp.getgrall() if user in g.gr_mem]  # compare user name with group database
+        gid = pwd.getpwnam(user).pw_gid                                   # make sure current group is added if database if incomplete
+        default_group = grp.getgrgid(gid).gr_name
+        if default_group not in groups:
+          groups.append(default_group)
+
+        return (default_group, groups)
 
     def _child_node_exists(self, parent_path, child_name, child_type):
         """

--- a/resources/project_create_dialog.ui
+++ b/resources/project_create_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>446</width>
-    <height>496</height>
+    <width>450</width>
+    <height>514</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -103,7 +103,7 @@ height: 100px;
        <item row="1" column="1">
         <widget class="QComboBox" name="volume"/>
        </item>
-       <item row="2" column="0">
+       <item row="3" column="0">
         <widget class="QLabel" name="label_6">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -116,7 +116,7 @@ height: 100px;
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="3" column="1">
         <widget class="QLabel" name="user_name">
          <property name="toolTip">
           <string>The &lt;b&gt;User Name&lt;/b&gt; associated with your new Flame Project is based on the Shotgun user that matches your current login name.
@@ -130,7 +130,7 @@ height: 100px;
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="label_19">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -143,7 +143,7 @@ height: 100px;
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="4" column="1">
         <widget class="QLabel" name="host_name">
          <property name="text">
           <string>xxx</string>
@@ -153,7 +153,14 @@ height: 100px;
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>&lt;b&gt;Setup Directory&lt;/b&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
         <widget class="QLabel" name="label_17">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -166,7 +173,7 @@ height: 100px;
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="5" column="1">
         <widget class="QLabel" name="workspace_name">
          <property name="text">
           <string>xxx</string>
@@ -175,6 +182,19 @@ height: 100px;
           <bool>false</bool>
          </property>
         </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="group_name_label">
+         <property name="text">
+          <string>&lt;b&gt;Group&lt;/b&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="QComboBox" name="group_name"/>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLineEdit" name="setup_dir"/>
        </item>
       </layout>
      </widget>
@@ -362,6 +382,11 @@ height: 100px;
          <property name="maxVisibleItems">
           <number>100</number>
          </property>
+         <item>
+          <property name="text">
+           <string>32-bit</string>
+          </property>
+         </item>
          <item>
           <property name="text">
            <string>16-bit fp</string>


### PR DESCRIPTION
Two new functionality 

1- Select project group id.
This follows security features for flame 2018.1. We want to allow the user to select the group id of the project when creating it.

2- Specify custom project setup directory
Unfortunately for this one, we only added a simple text field for the path instead of a QFileDialog. With the file dialog, you turns out to actually create the setup directory before creating the project which cause the setup directory to have the wrong permission. Flame needs to be the one the create the setup directory.