### PR TITLE
Fix 32 bit support for project creation

### DIFF
--- a/python/tk_flame/project_create_dialog.py
+++ b/python/tk_flame/project_create_dialog.py
@@ -83,8 +83,12 @@ class ProjectCreateDialog(QtGui.QWidget):
         self.ui.group_name.setCurrentIndex(idx)
 
         if self._engine.is_version_less_than("2018.1"):
+            # no security support in wiretap before 2018.1
             self.ui.group_name_label.setVisible(False)
             self.ui.group_name.setVisible(False)
+
+            # no 32-bit fp support in wiretap before 2018.1
+            self.ui.depth.removeItem(0)
 
         # populate the resolution tab
         self.__populate_resolution_tab(project_settings)

--- a/python/tk_flame/ui/project_create_dialog.py
+++ b/python/tk_flame/ui/project_create_dialog.py
@@ -417,7 +417,7 @@ class Ui_ProjectCreateDialog(object):
         self.frame_rate.setItemText(8, QtGui.QApplication.translate("ProjectCreateDialog", "59.94 fps NDF", None, QtGui.QApplication.UnicodeUTF8))
         self.frame_rate.setItemText(9, QtGui.QApplication.translate("ProjectCreateDialog", "60 fps", None, QtGui.QApplication.UnicodeUTF8))
         self.label_3.setText(QtGui.QApplication.translate("ProjectCreateDialog", "Depth", None, QtGui.QApplication.UnicodeUTF8))
-        self.depth.setItemText(0, QtGui.QApplication.translate("ProjectCreateDialog", "32-bit", None, QtGui.QApplication.UnicodeUTF8))
+        self.depth.setItemText(0, QtGui.QApplication.translate("ProjectCreateDialog", "32-bit fp", None, QtGui.QApplication.UnicodeUTF8))
         self.depth.setItemText(1, QtGui.QApplication.translate("ProjectCreateDialog", "16-bit fp", None, QtGui.QApplication.UnicodeUTF8))
         self.depth.setItemText(2, QtGui.QApplication.translate("ProjectCreateDialog", "12-bit", None, QtGui.QApplication.UnicodeUTF8))
         self.depth.setItemText(3, QtGui.QApplication.translate("ProjectCreateDialog", "12-bit u", None, QtGui.QApplication.UnicodeUTF8))

--- a/resources/project_create_dialog.ui
+++ b/resources/project_create_dialog.ui
@@ -384,7 +384,7 @@ height: 100px;
          </property>
          <item>
           <property name="text">
-           <string>32-bit</string>
+           <string>32-bit fp</string>
           </property>
          </item>
          <item>


### PR DESCRIPTION
-The "32-bit fp" had a type and wasn't recognized by wiretap.
-The 32 bit options had to be removed for flame pre 2018.1.