### PR TITLE
Fix Shotgun Shot Export for flame 2016.1 to 2017.2

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -925,14 +925,16 @@ class FlameEngine(sgtk.platform.Engine):
         # Specifying a remote backburner manager is only supported on 2016.1 and above
         if not self.is_version_less_than("2016.1"):
             bb_manager = self.get_setting("backburner_manager")
-            if not bb_manager :
+            if not bb_manager and not self.is_version_less_than("2018"):
                 # No backburner manager speficied in settings. Ask local backburnerServer
                 # which manager to choose from. (They might be none running locally)
+                # Before 2018, you needed root privileges to execute this command.
                 backburner_server_cmd = os.path.join(self._install_root, "backburner", "backburnerServer")
                 bb_manager = subprocess.check_output([backburner_server_cmd, "-q", "MANAGER"])
                 bb_manager = bb_manager.strip("\n")
 
-            backburner_args.append("-manager:\"%s\"" % bb_manager)
+            if bb_manager :
+                backburner_args.append("-manager:\"%s\"" % bb_manager)
 
         if backburner_server_host:
             backburner_args.append("-servers:\"%s\"" % backburner_server_host)


### PR DESCRIPTION
The problem:
Originally, this behavior got added to enable remote backburner manager for the shotgun plugin. However, it seems calling the ./backbunerServer command line requires root privileges in flame 2017.

Example (flame 2017.1 sp2) :
./backburnerServer -q MANAGER
ERR: Failed to open /opt/Autodesk/backburner/Network/backburner.xml: Permission denied (13).
Unable to initialize the Backburner server.

The fix:
Do not call this command before 2018. This feature was a lot more important for the plugin because it is not configurable (the plugin starts with flame 2018)
