### PR TITLE
Fix Shot Export on Mac and RHEL6 for flame 2016 and 2017

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -977,11 +977,10 @@ class FlameEngine(sgtk.platform.Engine):
         if os.getuid() == 0:  # root
             # Getting the user name of the user who started Flame (the effective user)
             e_user = pwd.getpwuid(os.geteuid()).pw_name
-            e_group = grp.getgrgid(os.getegid()).gr_name
 
             # Run the command as the effective user
-            full_cmd = "sudo -g %s -u %s bash -c %s" % (e_group, e_user, pipes.quote(full_cmd))
-            self.log_debug("Running root but will send the job as [%s] of the [%s] group" % (e_user, e_group))
+            full_cmd = "sudo -u %s bash -c %s" % (e_user, pipes.quote(full_cmd))
+            self.log_debug("Running root but will send the job as [%s]" % e_user)
 
         try:
             # Make sure that the session is not expired


### PR DESCRIPTION
The problem:
The switch "-g" does not work on Mac and Redhat 6 when lauching a the commant "sudo -g <group> <cmd>"

The fix:
Removed the -g switch.
In this workflow, we are more worried about reading permissions then writing permissions. Group id is more relevant when you write something on disk that need to be restricted to a group of user.