### PR TITLE
SMOK-45189 | More robust version check

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -30,7 +30,6 @@ import traceback
 import datetime
 import subprocess
 from sgtk import TankError
-from distutils.version import LooseVersion
 
 LOG_CHANNEL = "sgtk.tk-flame"
 
@@ -180,16 +179,17 @@ class FlameEngine(sgtk.platform.Engine):
         self._python_executable_path = python_path
         self.log_debug("This engine is running python interpreter '%s'" % self._python_executable_path )
         
-    def set_version_info(self, major_version_str, minor_version_str, full_version_str):
+    def set_version_info(self, major_version_str, minor_version_str, full_version_str, patch_version_str="0"):
         """
         Specifies which version of Flame this engine is running.
         This is typically populated as part of the engine startup.
         
         :param major_version_str: Major version number as string 
         :param minor_version_str: Minor version number as string
+        :param patch_version_str: Patch version number as string
         :param full_version_str: Full version number as string
         """
-        self._flame_version = {"full": full_version_str, "major": major_version_str, "minor": minor_version_str}
+        self._flame_version = {"full": full_version_str, "major": major_version_str, "minor": minor_version_str, "patch": patch_version_str}
         self.log_debug("This engine is running with Flame version '%s'" % self._flame_version )
 
     def set_install_root(self, install_root):
@@ -372,6 +372,31 @@ class FlameEngine(sgtk.platform.Engine):
             self.flame_version
         )
 
+    def _is_version_less_than(self, major, minor, patch):
+        """
+        Compares the given version numbers with the current 
+        flame version and returns False if the given version is 
+        greater than the current version.
+
+        Example:
+
+        - Flame: '2016.1.0.278', version str: '2016.1' => False
+        - Flame: '2016',  version str: '2016.1' => True
+
+        :param version_str: Version to run comparison against
+        """
+        if int(self.flame_major_version) != int(major):
+            return int(self.flame_major_version) < int(major)
+
+        if int(self.flame_minor_version) != int(minor):
+            return int(self.flame_minor_version) < int(minor)
+
+        if int(self.flame_patch_version) != int(patch):
+            return int(self.flame_patch_version) < int(patch)
+
+        # Same version
+        return False
+
     def is_version_less_than(self, version_str):
         """
         Compares the given version string with the current 
@@ -385,11 +410,25 @@ class FlameEngine(sgtk.platform.Engine):
         
         :param version_str: Version to run comparison against
         """
-        if self._flame_version is None:
-            raise TankError("No Flame DCC version specified!")
-        
-        curr_version = self._flame_version["full"]
-        return LooseVersion(curr_version) < LooseVersion(version_str)
+
+        major_ver = 0
+        minor_ver = 0
+        patch_ver = 0
+
+        chunks = version_str.split(".")
+        if len(chunks) > 0:
+            if chunks[0].isdigit():
+                major_ver = int(chunks[0])
+
+        if len(chunks) > 1:
+            if chunks[1].isdigit():
+                minor_ver = int(chunks[1])
+
+        if len(chunks) > 2:
+            if chunks[2].isdigit():
+                patch_ver = int(chunks[2])
+
+        return self._is_version_less_than(major_ver, minor_ver, patch_ver)
 
     @property
     def flame_major_version(self):
@@ -415,6 +454,18 @@ class FlameEngine(sgtk.platform.Engine):
         
         return self._flame_version["minor"]
     
+    @property
+    def flame_patch_version(self):
+        """
+        Returns Flame's patch version number as a string.
+
+        :returns: String (e.g. '2')
+        """
+        if self._flame_version is None:
+            raise TankError("No Flame DCC version specified!")
+
+        return self._flame_version["patch"]
+
     @property
     def flame_version(self):
         """

--- a/flame_hooks/sg_project_hook.py
+++ b/flame_hooks/sg_project_hook.py
@@ -74,11 +74,12 @@ def appInitialized(projectName):
         # and the version number
         major_version_str = os.environ.get("TOOLKIT_FLAME_MAJOR_VERSION")
         minor_version_str = os.environ.get("TOOLKIT_FLAME_MINOR_VERSION")
+        patch_version_str = os.environ.get("TOOLKIT_FLAME_PATCH_VERSION")
         full_version_str = os.environ.get("TOOLKIT_FLAME_VERSION")
         
-        if None in (major_version_str, minor_version_str, full_version_str):
+        if None in (major_version_str, minor_version_str, patch_version_str, full_version_str):
             e.log_error("Cannot find environment variable TOOLKIT_FLAME_x_VERSION")
         else:
-            e.set_version_info(major_version_str, minor_version_str, full_version_str)
+            e.set_version_info(major_version_str=major_version_str, minor_version_str=minor_version_str, patch_version_str=patch_version_str, full_version_str=full_version_str)
         
         

--- a/python/startup/app_launcher.py
+++ b/python/startup/app_launcher.py
@@ -39,7 +39,7 @@ import sys
 
 try:
     import sgtk
-    from sgtk import TankError    
+    from sgtk import TankError
 except ImportError:
     raise Exception("Could not find the sgtk library in the PYTHONPATH")
 
@@ -62,7 +62,7 @@ def launch_flame(dcc_path, dcc_args):
     engine_instance_name = os.environ["TOOLKIT_ENGINE_NAME"]
     context_str = os.environ["TOOLKIT_CONTEXT"]
     context = sgtk.context.deserialize(context_str)
-    
+
     # start up Flame engine
     # set a special environment variable to help hint to the engine
     # that when it is started this time, it is part of the bootstrap
@@ -87,16 +87,18 @@ def launch_flame(dcc_path, dcc_args):
     # and the version number
     major_version_str = os.environ.get("TOOLKIT_FLAME_MAJOR_VERSION")
     minor_version_str = os.environ.get("TOOLKIT_FLAME_MINOR_VERSION")
+    patch_version_str = os.environ.get("TOOLKIT_FLAME_MINOR_VERSION")
     full_version_str = os.environ.get("TOOLKIT_FLAME_VERSION")
-    
-    if None in (major_version_str, minor_version_str, full_version_str):
+
+    if None in (major_version_str, minor_version_str, patch_version_str, full_version_str):
         flame_engine.log_error("Cannot find environment variable TOOLKIT_FLAME_x_VERSION")
     else:
-        flame_engine.set_version_info(major_version_str, minor_version_str, full_version_str)
-        
+        flame_engine.set_version_info(major_version_str=major_version_str, minor_version_str=minor_version_str,
+                                      patch_version_str=patch_version_str, full_version_str=full_version_str)
+
     # and kick off the pre-process - this will ensure that a Flame project exists.
     app_args = flame_engine.pre_dcc_launch_phase()
-    
+
     # now launch Flame!
     flame_engine.log_debug("-" * 60)
     flame_engine.log_debug("About to launch the actual flame DCC.")
@@ -108,7 +110,6 @@ def launch_flame(dcc_path, dcc_args):
     flame_engine.log_debug("-" * 60)
 
     return os.system(cmd_line)
-    
 
 
 if __name__ == "__main__":
@@ -117,10 +118,10 @@ if __name__ == "__main__":
     if len(sys.argv) == 1:
         print "Invalid syntax: app_launcher /path/to/flame args!"
         sys.exit(1)
-        
+
     # the location of the actual tank core installation
     dcc_path = sys.argv[1]
-    
+
     # rest of the arguments are stuff we should pass to the DCC
     dcc_args = sys.argv[2:]
 
@@ -129,6 +130,5 @@ if __name__ == "__main__":
         exit_code = launch_flame(dcc_path, dcc_args)
     except KeyboardInterrupt, e:
         print "Process cancelled."
-
 
     sys.exit(exit_code)

--- a/python/startup/backburner.py
+++ b/python/startup/backburner.py
@@ -65,7 +65,7 @@ context = sgtk.context.deserialize(serialized_context)
 # that we are running a backburner job
 os.environ["TOOLKIT_FLAME_ENGINE_MODE"] = "BACKBURNER"
 engine = sgtk.platform.start_engine(engine_instance, context.sgtk, context)
-engine.set_version_info(flame_version["major"], flame_version["minor"], flame_version["full"])
+engine.set_version_info(major_version_str=flame_version["major"], minor_version_str=flame_version["minor"], patch_version_str=flame_version["patch"], full_version_str=flame_version["full"])
 del os.environ["TOOLKIT_FLAME_ENGINE_MODE"]
 engine.log_debug("Engine launched for backburner process.")
 

--- a/python/startup/bootstrap.py
+++ b/python/startup/bootstrap.py
@@ -20,16 +20,16 @@ def _get_flame_version(flame_path):
     """
     Returns the version string for the given Flame path
     
-    <INSTALL_ROOT>/flameassist_2016.2/bin/startApplication        --> (2016, 2, "2016.2")
-    <INSTALL_ROOT>/flameassist_2016.3/bin/startApplication        --> (2016, 3, "2016.3")
-    <INSTALL_ROOT>/flameassist_2016.0.0.322/bin/startApplication  --> (2016, 0, "2016.0.0.322")
-    <INSTALL_ROOT>/flameassist_2016.2.pr99/bin/startApplication   --> (2016, 2, "2016.2.pr99")
-    <INSTALL_ROOT>/flame_2016.pr50/bin/start_Flame                --> (2016, 0, "2016.pr50")
+    <INSTALL_ROOT>/flameassist_2016.2/bin/startApplication        --> (2016, 2, 0, "2016.2")
+    <INSTALL_ROOT>/flameassist_2016.3/bin/startApplication        --> (2016, 3, 0, "2016.3")
+    <INSTALL_ROOT>/flameassist_2016.0.3.322/bin/startApplication  --> (2016, 0, 3, "2016.0.3.322")
+    <INSTALL_ROOT>/flameassist_2016.2.pr99/bin/startApplication   --> (2016, 2, 0, "2016.2.pr99")
+    <INSTALL_ROOT>/flame_2016.pr50/bin/start_Flame                --> (2016, 0, 0, "2016.pr50")
 
-    If the minor or major version cannot be extracted, it will be set to zero.
+    If the patch, minor or major version cannot be extracted, it will be set to zero.
 
     :param flame_path: path to executable
-    :returns: (major, minor, full_str)
+    :returns: (major, minor, patch, full_str)
     """
 
     # do a quick check to ensure that we are running 2015.2 or later
@@ -46,6 +46,7 @@ def _get_flame_version(flame_path):
 
     major_ver = 0
     minor_ver = 0
+    patch_ver = 0
 
     chunks = version_str.split(".")
     if len(chunks) > 0:
@@ -56,7 +57,11 @@ def _get_flame_version(flame_path):
         if chunks[1].isdigit():
             minor_ver = int(chunks[1])
 
-    return (major_ver, minor_ver, version_str)
+    if len(chunks) > 2:
+        if chunks[2].isdigit():
+            patch_ver = int(chunks[2])
+
+    return (major_ver, minor_ver, patch_ver, version_str)
 
 
 def bootstrap(engine_instance_name, context, app_path, app_args):
@@ -100,7 +105,7 @@ def bootstrap(engine_instance_name, context, app_path, app_args):
     app_path = os.path.realpath(app_path)
 
     # do a quick check to ensure that we are running 2015.2 or later
-    (major_ver, minor_ver, version_str) = _get_flame_version(app_path)
+    (major_ver, minor_ver, patch_ver, version_str) = _get_flame_version(app_path)
 
     if major_ver < 2016:
         raise TankError("In order to run the Shotgun integration, you need at least Flame 2016!")
@@ -165,6 +170,7 @@ def bootstrap(engine_instance_name, context, app_path, app_args):
     # also pass the version of Flame in the same manner
     os.environ["TOOLKIT_FLAME_MAJOR_VERSION"] = str(major_ver)
     os.environ["TOOLKIT_FLAME_MINOR_VERSION"] = str(minor_ver)
+    os.environ["TOOLKIT_FLAME_PATCH_VERSION"] = str(patch_ver)
     os.environ["TOOLKIT_FLAME_VERSION"] = version_str
 
     # and the install location

--- a/python/tk_flame/wiretap.py
+++ b/python/tk_flame/wiretap.py
@@ -258,7 +258,7 @@ class WiretapHandler(object):
             xml += self._append_setting_to_xml(project_settings, "FrameDepth")
             xml += self._append_setting_to_xml(project_settings, "AspectRatio")
             xml += self._append_setting_to_xml(project_settings, "FrameRate")
-            xml += self._append_setting_to_xml(project_settings, "ProxyEnable", stops_working_in="2016.1")            
+            xml += self._append_setting_to_xml(project_settings, "ProxyEnable", stops_working_in="2016.1")
             xml += self._append_setting_to_xml(project_settings, "FieldDominance")            
             xml += self._append_setting_to_xml(project_settings, "VisualDepth", starts_working_in="2015.3", stops_working_in="2018.0")
 
@@ -321,7 +321,6 @@ class WiretapHandler(object):
                 
             else:
                 xml = "<%s>%s</%s>" % (setting, project_settings.get(setting), setting)
-    
         return xml
     
 


### PR DESCRIPTION
This allow to have a more robust version check than the one with LooseVersion who were acting bad with some of our version naming.

Ex: "2018.caseXXXXXXXX" (2018.0.0) was seen greater than "2018.1" (2018.1.0) because 'c' come before '1' with LooseVersion but not in our case.