### PR TITLE
Add a configuration entry about Backburner groups

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -991,11 +991,23 @@ class FlameEngine(sgtk.platform.Engine):
             if bb_manager :
                 backburner_args.append("-manager:\"%s\"" % bb_manager)
 
+        # Set the server group to the backburner job
+        bb_server_group = self.get_setting("backburner_server_group")
+        if bb_server_group:
+            backburner_args.append("-group:\"%s\"" % bb_server_group)
+
+        # Specify the backburner server if provided
         if backburner_server_host:
             backburner_args.append("-servers:\"%s\"" % backburner_server_host)
+        # Otherwise, fallback to the global backburner servers setting
+        else:
+            bb_servers = self.get_setting("backburner_servers")
+            if bb_servers:
+                backburner_args.append("-servers:\"%s\"" % bb_servers)
 
+        # Set the backburner job dependencies
         if run_after_job_id:
-            backburner_args.append("-dependencies:%s" % run_after_job_id) # run after another job
+            backburner_args.append("-dependencies:%s" % run_after_job_id)
 
         # call the bootstrap script
         backburner_bootstrap = os.path.join(self.disk_location, "python", "startup", "backburner.py")

--- a/info.yml
+++ b/info.yml
@@ -51,6 +51,17 @@ configuration:
                      a larger backburner setup, this path must be some sort of shared network
                      location. 
 
+    backburner_servers:
+        type: str
+        default_value: ""
+        description: Comma separated list of servers to use when submitting a backburner job.
+                     (Ignored if a group is used)
+
+    backburner_server_group:
+        type: str
+        default_value: ""
+        description: The group name of the servers to use when submitting a backburner job.
+
     run_at_startup:
         type: list
         description: "Controls what apps will run on startup.  This is a list where each element


### PR DESCRIPTION
JIRA: SMOK-46429

DESCRIPTION

The Shotgun upload jobs cannot be assigned to specific server(s) and get
assigned to any servers available in the Backburner Manager pool.
This lack of option is problematic as Shotgun upload jobs get processed
by workstations that should not be used for such of jobs.

DOC

backburner_servers:
	type: str
       	default_value: ""
        description: Comma separated list of servers to use when submitting a backburner job.(Ignored if a group is used)

backburner_server_group:
        type: str
        default_value: ""
        description: The group name of the servers to use when submitting a backburner job.