### PR TITLE
For #44071: Only warns the user if crossing SG project bounds.

### DIFF
--- a/flame_hooks/sg_project_hook.py
+++ b/flame_hooks/sg_project_hook.py
@@ -51,7 +51,7 @@ def appInitialized(projectName):
 
         try:
             import flame
-        except ImportError:
+        except Exception:
             pass
         else:
             try:

--- a/flame_hooks/sg_project_hook.py
+++ b/flame_hooks/sg_project_hook.py
@@ -52,7 +52,13 @@ def appInitialized(projectName):
         try:
             import flame
         except Exception:
-            pass
+            logger.debug(
+                "Was unable to import the flame Python module. As such, "
+                "it must be assumed that the Flame project change is "
+                "resulting in a change in Shotgun project. This means "
+                "that the user will see a QMessageBox warning if the "
+                "tk-flame engine's project_switching setting is false."
+            )
         else:
             try:
                 current_flame_project = flame.project.current_project
@@ -70,11 +76,13 @@ def appInitialized(projectName):
         # rather than going through the sgtk wrappers.
         if engine.get_setting("project_switching") is False and project_is_changing:
             from PySide import QtGui
-            QtGui.QMessageBox.warning(None,
-                                      "No project switching!",
-                                      "The Shotgun integration does not currently support project switching.\n"
-                                      "Even if you switch projects, any Shotgun-specific configuration will\n"
-                                      "remain connected to the initially loaded project.")
+            QtGui.QMessageBox.warning(
+                None,
+                "No project switching!",
+                "The Shotgun integration does not currently support project switching.\n"
+                "Even if you switch projects, any Shotgun-specific configuration will\n"
+                "remain connected to the initially loaded project."
+            )
     
     else:
         # no engine running - so start one!
@@ -115,6 +123,11 @@ def appInitialized(projectName):
         if None in (major_version_str, minor_version_str, patch_version_str, full_version_str):
             e.log_error("Cannot find environment variable TOOLKIT_FLAME_x_VERSION")
         else:
-            e.set_version_info(major_version_str=major_version_str, minor_version_str=minor_version_str, patch_version_str=patch_version_str, full_version_str=full_version_str)
+            e.set_version_info(
+                major_version_str=major_version_str,
+                minor_version_str=minor_version_str,
+                patch_version_str=patch_version_str,
+                full_version_str=full_version_str
+            )
         
         

--- a/flame_hooks/sg_project_hook.py
+++ b/flame_hooks/sg_project_hook.py
@@ -23,7 +23,6 @@ def appInitialized(projectName):
     import os    
 
     engine = sgtk.platform.current_engine()
-    logger = sgtk.LogManager.get_logger(__name__)
 
     if engine:
         # there is already an engine running.
@@ -52,25 +51,27 @@ def appInitialized(projectName):
         try:
             import flame
         except Exception:
-            logger.debug(
+            engine.logger.debug(
                 "Was unable to import the flame Python module. As such, "
                 "it must be assumed that the Flame project change is "
                 "resulting in a change in Shotgun project. This means "
                 "that the user will see a QMessageBox warning if the "
-                "tk-flame engine's project_switching setting is false."
+                "tk-flame engine's project_switching setting is false. "
+                "The API to allow this was introduced in 2018.2."
             )
         else:
             try:
                 current_flame_project = flame.project.current_project
                 new_sg_project = current_flame_project.shotgun_project_name.get_value()
-                project_is_changing = (new_sg_project != engine.context.project.get("name"))
             except Exception:
-                logger.debug(
+                engine.logger.debug(
                     "Failed to get the SG project from the current Flame project. "
                     "As a result, falling back on the engine's project_switching "
                     "setting to determine whether to show the user a warning stating "
                     "that project switching might not behave as expected."
                 )
+            else:
+                project_is_changing = (new_sg_project != engine.context.project.get("name"))
 
         # Note - Since Flame is a PySide only environment, we import it directly
         # rather than going through the sgtk wrappers.
@@ -90,6 +91,7 @@ def appInitialized(projectName):
         toolkit_context = os.environ.get("TOOLKIT_CONTEXT")
         
         if toolkit_context is None:
+            logger = sgtk.LogManager.get_logger(__name__)
             logger.debug("No toolkit context, can't initialize the engine")
             return
         


### PR DESCRIPTION
When a Flame project is changed within the session, we've traditionally warned the user that we haven't changed Shotgun projects. This was a bit of a catch-all, in that it didn't check to see if the SG project actually would change. Here, we now only show that warning to the user if it appears as though we're also crossing SG Project bounds.