### PR TITLE
Multiple feedbacks.

### DIFF
--- a/flame_hooks/sg_batch_hook.py
+++ b/flame_hooks/sg_batch_hook.py
@@ -139,20 +139,12 @@ def batchExportEnd(info, userData):
     engine.cache_batch_export_asset(info)
     engine.trigger_batch_callback("batchExportEnd", info)
 
-
-def renderEnded(module_name, sequence_name, elapsed):
-    import sgtk
-    engine = sgtk.platform.current_engine()
-
-    # We can't do anything without the Shotgun engine.
-    # The engine is None when the user decides to not use the plugin for the project.
-    if engine is None:
-        return
-
     publisher = engine.apps.get("tk-multi-publish2")
 
     if publisher and not os.environ.get("SHOTGUN_DISABLE_POST_RENDER_PUBLISH"):
         if engine.export_info:
-            import gc; gc.disable()  # SMOK-46824 - PySide garbage collection issue
-            publisher.import_module("tk_multi_publish2").show_dialog(publisher)
-            gc.enable()
+            tk_multi_publish2 = publisher.import_module("tk_multi_publish2")
+            tk_multi_publish2.show_dialog(publisher)
+
+# tell Flame not to display the fish cursor while we process the hook
+batchExportEnd.func_dict["waitCursor"] = False

--- a/flame_hooks/sg_export_hook.py
+++ b/flame_hooks/sg_export_hook.py
@@ -172,10 +172,11 @@ def postExport(info, userData):
         publisher = engine.apps.get("tk-multi-publish2")
         if publisher and not os.environ.get("SHOTGUN_DISABLE_POST_EXPORT_PUBLISH"):
             if engine.export_info:
-                import gc; gc.disable()  # SMOK-46824 - PySide garbage collection issue
-                publisher.import_module("tk_multi_publish2").show_dialog(publisher)
-                gc.enable()
+                tk_multi_publish2 = publisher.import_module("tk_multi_publish2")
+                tk_multi_publish2.show_dialog(publisher)
 
+# tell Flame not to display the fish cursor while we process the hook
+postExport.func_dict["waitCursor"] = False
 
 def preExportSequence(info, userData):
     """

--- a/hooks/tk-multi-publish2/collector.py
+++ b/hooks/tk-multi-publish2/collector.py
@@ -90,13 +90,14 @@ class FlameItemCollector(HookBaseClass):
         self.engine = self.publisher.engine
         self.sg = self.engine.shotgun
 
-    def process_current_session(self, parent_item):
+    def process_current_session(self, settings, parent_item):
         """
         Create Items from the flame latest export action.
 
         This action could be an Export from the MediaLibrary or a Render from Batch.
 
-        :param parent_item: Invisible root item of the publisher app
+        :param dict settings: Configured settings for this collector
+        :param parent_item: Root item instance
         """
 
         # Current project
@@ -218,6 +219,9 @@ class FlameItemCollector(HookBaseClass):
                                     else:
                                         item.context = self.publisher.sgtk.context_from_entity_dictionary(project)
 
+                                    # This item cannot have another context than this one
+                                    item.context_change_allowed = False
+
         # When the action is a render, the export_info is a list of asset
         elif type(export_context) == list:
             # We have a list of asset
@@ -266,6 +270,9 @@ class FlameItemCollector(HookBaseClass):
                         item.context = self.publisher.sgtk.context_from_entity_dictionary(shot)
                     else:
                         item.context = self.publisher.sgtk.context_from_entity_dictionary(project)
+
+                    # This item cannot have another context than this one
+                    item.context_change_allowed = False
 
     def cache_entities(self, item, entities):
         """
@@ -397,7 +404,7 @@ class FlameItemCollector(HookBaseClass):
 
         if is_sequence:
             # generate the name from one of the actual files in the sequence
-            name_path = sequence[0]
+            name_path = self.publisher.util.get_frame_sequence_path(sequence[0])
         else:
             name_path = path
 
@@ -414,7 +421,7 @@ class FlameItemCollector(HookBaseClass):
             item.properties["is_sequence"] = True
             item.properties["sequence_files"] = sequence
 
-        item.properties["path"] = path
+        item.properties["path"] = name_path
 
         return [item]
 

--- a/hooks/tk-multi-publish2/collector.py
+++ b/hooks/tk-multi-publish2/collector.py
@@ -422,6 +422,7 @@ class FlameItemCollector(HookBaseClass):
             item.properties["sequence_files"] = sequence
 
         item.properties["path"] = name_path
+        item.properties["file_path"] = path
 
         return [item]
 

--- a/hooks/tk-multi-publish2/create_version.py
+++ b/hooks/tk-multi-publish2/create_version.py
@@ -154,7 +154,6 @@ class CreateVersionPlugin(HookBaseClass):
             sg_path_to_frames=path
         )
 
-        # TODO: Might be a setting
         ver_data["sg_department"] = "Flame"
 
         asset_info = item.properties.get("assetInfo", {})
@@ -186,6 +185,9 @@ class CreateVersionPlugin(HookBaseClass):
         # Extract the Backburner dependencies
         job_ids = item.properties.get("backgroundJobId")
         job_ids_str = ",".join(job_ids) if job_ids else None
+
+        # For file sequences, the hooks we want the path as provided by flame.
+        path = item.properties.get("file_path", path)
 
         # Create the Image thumbnail in background
         self.engine.create_local_backburner_job(

--- a/hooks/tk-multi-publish2/publish_file.py
+++ b/hooks/tk-multi-publish2/publish_file.py
@@ -180,6 +180,9 @@ class CreatePublishPlugin(HookBaseClass):
             job_ids = item.properties.get("backgroundJobId")
             job_ids_str = ",".join(job_ids) if job_ids else None
 
+            # For file sequences, the hooks we want the path as provided by flame.
+            path = item.properties.get("file_path", path)
+
             # Create the Image thumbnail in background
             self.engine.create_local_backburner_job(
                 "Upload PublishedFile Image Preview",

--- a/hooks/tk-multi-publish2/update_cut_item.py
+++ b/hooks/tk-multi-publish2/update_cut_item.py
@@ -180,6 +180,9 @@ class UpdateCutPlugin(HookBaseClass):
         job_ids = item.properties.get("backgroundJobId")
         job_ids_str = ",".join(job_ids) if job_ids else None
 
+        # For file sequences, the hooks we want the path as provided by flame.
+        path = item.properties.get("file_path", path)
+
         # Create the Image thumbnail in background
         self.engine.create_local_backburner_job(
             "Upload Cut Item Image Preview",

--- a/hooks/tk-multi-publish2/update_shot.py
+++ b/hooks/tk-multi-publish2/update_shot.py
@@ -228,6 +228,7 @@ class UpdateShotPlugin(HookBaseClass):
         shot_data["sg_tail_out"] = shot_data["sg_cut_out"] + asset_info["handleOut"]
 
         shot_data["sg_cut_duration"] = shot_data["sg_cut_out"] - shot_data["sg_cut_in"] + 1
+        shot_data["sg_working_duration"] = shot_data["sg_tail_out"] - shot_data["sg_head_in"] + 1
 
         return shot_data
 


### PR DESCRIPTION
General:
- Remove warning based on bad assumption
- Cache the Qt dialog in the engine memory
- Override show_dialog method of the engine to have always on top dialogs
- Fix a FIXME :)

Publisher
- Disable the wait cursor on the publisher hooks
- Add working duration field on the shot metadata
- Use the %d file sequence way instead of [] (Required by others integrations...)