### PR TITLE
Uninitialize the engine upon Flame exit

### DIFF
--- a/flame_hooks/sg_hook.py
+++ b/flame_hooks/sg_hook.py
@@ -10,6 +10,14 @@
 
 import os
 
+def appExit( info ):
+    engine = sgtk.platform.current_engine()
+
+    # Nothing to do if no Shotgun engine has been initialized.
+    if engine is not None:
+        engine.destroy()
+
+
 def getCustomUIActions():
 
     version = [os.environ.get("SHOTGUN_FLAME_MAJOR_VERSION"), os.environ.get("TOOLKIT_FLAME_MAJOR_VERSION")]

--- a/flame_hooks/sg_hook.py
+++ b/flame_hooks/sg_hook.py
@@ -11,6 +11,7 @@
 import os
 
 def appExit( info ):
+    import sgtk
     engine = sgtk.platform.current_engine()
 
     # Nothing to do if no Shotgun engine has been initialized.


### PR DESCRIPTION
JIRA: SMOK-48303
Shotgun engine not shut down when exiting application

If any apps or the engine point to flame object, they need to be destroyed
before the application quit since uninitializing them during static uninit
could lead to problems.