### PR TITLE
Support write file node render without shot entity

### DIFF
--- a/hooks/tk-multi-publish2/create_cut_item.py
+++ b/hooks/tk-multi-publish2/create_cut_item.py
@@ -116,7 +116,7 @@ class CreateCutPlugin(HookBaseClass):
         cut_supported = self.sg.server_caps.version >= (7, 0, 0)
 
         # Only available on Shot entity
-        shot_context = item.context.entity and item.context.entity.get("type", "") == "Shot"
+        shot_context = item.context.entity and item.context.entity.get("type") == "Shot"
 
         # Not available from batch render
         accepted = cut_supported and shot_context and not item.properties.get("fromBatch", False)

--- a/hooks/tk-multi-publish2/update_cut_item.py
+++ b/hooks/tk-multi-publish2/update_cut_item.py
@@ -117,9 +117,9 @@ class UpdateCutPlugin(HookBaseClass):
         cut_supported = self.sg.server_caps.version >= (7, 0, 0)
 
         # Only available on Shot context
-        shot_context = item.context.entity["type"] == "Shot"
+        shot_context = item.context.entity and item.context.entity.get("type", "") == "Shot"
 
-        accepted = cut_supported and shot_context and item.properties["fromBatch"]
+        accepted = cut_supported and shot_context and item.properties.get("fromBatch", False)
 
         # If the context is correct, try to find the CutItem to Update
         if accepted:

--- a/hooks/tk-multi-publish2/update_cut_item.py
+++ b/hooks/tk-multi-publish2/update_cut_item.py
@@ -117,7 +117,7 @@ class UpdateCutPlugin(HookBaseClass):
         cut_supported = self.sg.server_caps.version >= (7, 0, 0)
 
         # Only available on Shot context
-        shot_context = item.context.entity and item.context.entity.get("type", "") == "Shot"
+        shot_context = item.context.entity and item.context.entity.get("type") == "Shot"
 
         accepted = cut_supported and shot_context and item.properties.get("fromBatch", False)
 

--- a/hooks/tk-multi-publish2/update_shot.py
+++ b/hooks/tk-multi-publish2/update_shot.py
@@ -114,7 +114,7 @@ class UpdateShotPlugin(HookBaseClass):
         """
 
         # Only available on a Shot Context and from a batch render
-        is_accepted = item.context.entity["type"] == "Shot" and not item.properties["fromBatch"]
+        is_accepted = item.context.entity and item.context.entity.get("type", "") == "Shot" and not item.properties.get("fromBatch", False)
 
         return {"accepted": is_accepted}
 

--- a/hooks/tk-multi-publish2/update_shot.py
+++ b/hooks/tk-multi-publish2/update_shot.py
@@ -114,7 +114,7 @@ class UpdateShotPlugin(HookBaseClass):
         """
 
         # Only available on a Shot Context and from a batch render
-        is_accepted = item.context.entity and item.context.entity.get("type", "") == "Shot" and not item.properties.get("fromBatch", False)
+        is_accepted = item.context.entity and item.context.entity.get("type") == "Shot" and not item.properties.get("fromBatch", False)
 
         return {"accepted": is_accepted}
 


### PR DESCRIPTION
JIRA: SMOK-48641

Rendering a write file node without a shot name or a pointing to a shot that
have not been created yet will cause an error.

The entity object could not be retrieved causing a python error when trying
to fetch attribute from it.