### PR TITLE
Set proper minimum tk-core based on previous fixes

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -117,5 +117,5 @@ description: "Shotgun Integration in Flame"
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.18.148"
+requires_core_version: "v0.18.45"
 


### PR DESCRIPTION
JIRA: SMOK-48559 SMOK-48675

Using "from PySide import x" requiere tk-core v0.18.45

I've upgraded the minimum to the latest by mistake in previous PR.