### PR TITLE
Do not show "Load in new Batch Group" option is no batch file present

### DIFF
--- a/hooks/tk-multi-loader2/flame_loader_actions.py
+++ b/hooks/tk-multi-loader2/flame_loader_actions.py
@@ -755,8 +755,6 @@ class FlameLoaderActions(HookBaseClass):
         :param sg_publish_data: Shotgun data dictionary with all the standard publish fields.
         :returns: The path to the batch file for the curent shot.
         """
-        import pdb
-        pdb.set_trace()
         sg_info = self._get_batch_info_from_sg_publish_data(sg_publish_data)
         batch_path = self._get_batch_path_from_published_files(sg_info)
         return batch_path if batch_path and self._exists(batch_path) else None


### PR DESCRIPTION
JIRA: SMOK-48548
"Load in new Batch Group" in SG loader should not be available on Movie export.

Refactor _add_batch_group_from_shot() to be able to call it partially from the
generate_actions() hook. This allow the action to be added only if the batch
setup is present.

While at it, I've exposed a bit more the error so when loading a batch
setup to a file that do not exists trigger an popup instead of just a error
in the log.

Fixed also some easy errors reported by PyLint around the code I've modified.