### PR TITLE
Flame 2019.1 integration

### DIFF
--- a/flame_hooks/sg_batch_hook.py
+++ b/flame_hooks/sg_batch_hook.py
@@ -1,27 +1,44 @@
 # Copyright (c) 2014 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
-# Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-# Note! This file implements the batchHook interface from Flame 2015.2
 import os
+
+
+def _show_publisher():
+    """
+    Show the publisher application
+    """
+
+    import sgtk
+
+    engine = sgtk.platform.current_engine()
+    if engine is None:
+        return
+
+    publisher = engine.apps.get("tk-multi-publish2")
+    if publisher and not os.environ.get("SHOTGUN_DISABLE_POST_RENDER_PUBLISH"):
+        if engine.export_info:
+            tk_multi_publish2 = publisher.import_module("tk_multi_publish2")
+            tk_multi_publish2.show_dialog(publisher)
 
 
 def batchSetupLoaded(setupPath):
     """
     Hook called when a batch setup is loaded.
-    
+
     :param setupPath: File path of the setup being loaded.
     """
     import sgtk
     engine = sgtk.platform.current_engine()
 
-    # We can't do anything without the Shotgun engine. 
+    # We can't do anything without the Shotgun engine.
     # The engine is None when the user decides to not use the plugin for the project.
     if engine is None:
         return
@@ -32,13 +49,13 @@ def batchSetupLoaded(setupPath):
 def batchSetupSaved(setupPath):
     """
     Hook called when a batch setup is saved.
-    
+
     :param setupPath: File path of the setup being loaded.
     """
     import sgtk
     engine = sgtk.platform.current_engine()
 
-    # We can't do anything without the Shotgun engine. 
+    # We can't do anything without the Shotgun engine.
     # The engine is None when the user decides to not use the plugin for the project.
     if engine is None:
         return
@@ -46,16 +63,76 @@ def batchSetupSaved(setupPath):
     engine.trigger_batch_callback("batchSetupSaved", {"setupPath": setupPath})
 
 
+def batchRenderBegin(info, userData, *args, **kwargs):
+    """
+    Hook called before a render begins. The render will be blocked
+    until this function returns.
+
+
+    :param info: Empty dictionary for now. Might have parameters in the future.
+
+    :param userData: Object that will be carried over into the render end hooks.
+                     This can be used by the hook to pass black box data around.
+
+    :note: This hook is available in Flame 2019.1 and up only.
+    """
+    import sgtk
+    engine = sgtk.platform.current_engine()
+
+    # We can't do anything without the Shotgun engine.
+    # The engine is None when the user decides to not use the plugin for the project.
+    if engine is None:
+        return
+
+    engine.clear_export_info()
+
+    engine.trigger_batch_callback("batchRenderBegin", info)
+
+
+def batchRenderEnd(info, userData, *args, **kwargs):
+    """
+    Hook called before a render ends.
+
+
+    :param info: Dictionary with a number of parameters:
+
+        aborted:              Indicate if the render has been aborted by the user.
+
+    :param userData: Object that could have been populated by the render begin hook.
+                     This can be used by the hook to pass black box data around.
+
+    :note: This hook is available in Flame 2019.1 and up only.
+    """
+    import sgtk
+    engine = sgtk.platform.current_engine()
+
+    # We can't do anything without the Shotgun engine.
+    # The engine is None when the user decides to not use the plugin for the project.
+    if engine is None:
+        return
+
+    engine.trigger_batch_callback("batchRenderEnd", info)
+
+    if info.get("aborted", False):
+        return
+
+    if isinstance(engine.export_info, list) and len(engine.export_info) > 0:
+        _show_publisher()
+
+# tell Flame not to display the fish cursor while we process the hook
+batchRenderEnd.func_dict["waitCursor"] = False
+
+
 def batchExportBegin(info, userData):
-    """    
+    """
     Hook called before an export begins. The export will be blocked
     until this function returns.  Note that for stereo export this
     function will be called twice (for left then right channel)
 
-    
+
     :param info: Dictionary with a number of parameters:
-    
-        nodeName:             Name of the export node.   
+
+        nodeName:             Name of the export node.
         exportPath:           [Modifiable] Export path as entered in the application UI.
                               Can be modified by the hook to change where the file are written.
         namePattern:          List of optional naming tokens as entered in the application UI.
@@ -74,8 +151,8 @@ def batchExportBegin(info, userData):
                               is enabled.
         setupResolvedPath:    Full path to the setup created if any with all the tokens resolved.
                               This is only available if versioning is enabled.
-    
-    
+
+
     :param userData: Object that could have been populated by previous export hooks and that
                      will be carried over into the subsequent export hooks.
                      This can be used by the hook to pass black box data around.
@@ -83,26 +160,24 @@ def batchExportBegin(info, userData):
     import sgtk
     engine = sgtk.platform.current_engine()
 
-    # We can't do anything without the Shotgun engine. 
+    # We can't do anything without the Shotgun engine.
     # The engine is None when the user decides to not use the plugin for the project.
     if engine is None:
         return
-
-    engine.clear_export_info()
 
     engine.trigger_batch_callback("batchExportBegin", info)
 
 
 def batchExportEnd(info, userData):
-    """    
+    """
     Hook called when an export ends. Note that for stereo export this
     function will be called twice (for left then right channel)
-    
+
     This function complements the above batchExportBegin function.
-    
+
     :param info: Dictionary with a number of parameters:
-    
-        nodeName:             Name of the export node.   
+
+        nodeName:             Name of the export node.
         exportPath:           Export path as entered in the application UI.
                               Can be modified by the hook to change where the file are written.
         namePattern:          List of optional naming tokens as entered in the application UI.
@@ -122,8 +197,8 @@ def batchExportEnd(info, userData):
         setupResolvedPath:    Full path to the setup created if any with all the tokens resolved.
                               This is only available if versioning is enabled.
         aborted:              Indicate if the export has been aborted by the user.
-    
-    
+
+
     :param userData: Object that could have been populated by previous export hooks and that
                      will be carried over into the subsequent export hooks.
                      This can be used by the hook to pass black box data around.
@@ -131,7 +206,7 @@ def batchExportEnd(info, userData):
     import sgtk
     engine = sgtk.platform.current_engine()
 
-    # We can't do anything without the Shotgun engine. 
+    # We can't do anything without the Shotgun engine.
     # The engine is None when the user decides to not use the plugin for the project.
     if engine is None:
         return
@@ -141,12 +216,6 @@ def batchExportEnd(info, userData):
     if not info.get("aborted", False):
         engine.cache_batch_export_asset(info)
 
-        publisher = engine.apps.get("tk-multi-publish2")
-
-        if publisher and not os.environ.get("SHOTGUN_DISABLE_POST_RENDER_PUBLISH"):
-            if engine.export_info:
-                tk_multi_publish2 = publisher.import_module("tk_multi_publish2")
-                tk_multi_publish2.show_dialog(publisher)
 
 # tell Flame not to display the fish cursor while we process the hook
 batchExportEnd.func_dict["waitCursor"] = False

--- a/hooks/tk-multi-publish2/publish_file.py
+++ b/hooks/tk-multi-publish2/publish_file.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2017 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
@@ -54,7 +54,7 @@ class CreatePublishPlugin(HookBaseClass):
         Verbose, multi-line description of what the plugin does. This can
         contain simple html for formatting.
         """
-        return "TBD"
+        return "Creates publish file in Shotgun for the given object"
 
     @property
     def settings(self):
@@ -184,19 +184,12 @@ class CreatePublishPlugin(HookBaseClass):
             path = item.properties.get("file_path", path)
 
             # Create the Image thumbnail in background
-            self.engine.create_local_backburner_job(
-                "Upload PublishedFile Image Preview",
-                item.name,
-                job_ids_str,
-                "backburner_hooks",
-                "attach_jpg_preview",
-                {
-                    "targets": [published_file],
-                    "width": asset_info["width"],
-                    "height": asset_info["height"],
-                    "path": path,
-                    "name": item.name
-                }
+            self.engine.thumbnail_generator.generate(
+                display_name=item.name,
+                path=path,
+                dependencies=item.properties.get("backgroundJobId"),
+                target_entities=[published_file],
+                asset_info=asset_info
             )
 
         # Save the PublishedFile for the others plugins
@@ -214,4 +207,4 @@ class CreatePublishPlugin(HookBaseClass):
         :param item: Item to process
         """
 
-        pass
+        self.engine.thumbnail_generator.finalize(path=item.properties["path"])

--- a/info.yml
+++ b/info.yml
@@ -16,12 +16,12 @@ configuration:
     debug_logging:
         type: bool
         description: Controls whether debug messages should be emitted to the logger
-        default_value: false
+        default_value: False
 
     project_switching:
         type: bool
         description: Hint about the possibility to switch project
-        default_value: false
+        default_value: False
 
     project_startup_hook:
         type: hook
@@ -66,6 +66,62 @@ configuration:
         type: str
         default_value: ""
         description: The group name of the servers to use when submitting a backburner job.
+
+
+    generate_thumbnails:
+        type: bool
+        default_value: True
+        description: Generate thumbnails for assets exported from Flame when submitting to Shotgun.
+
+    thumbnails_preset_path:
+        type: str
+        default_value: "Generate Thumbnail.xml"
+        description: Path to the preset to use to generate thumbnails. If a relative path
+                     is passed, the path to the application specific presets for Shotgun will
+                     be prepended (/opt/Autodesk/presets/<version>/export/presets/shotgun/file_sequence).
+                     This setting only apply from Flame 2019.1 and above.
+
+    generate_previews:
+        type: bool
+        default_value: True
+        description: Generate preview for assets exported from Flame when submitting to Shotgun.
+                     Not all Shotgun entities supports preview and the code will fallback on thumbnail
+                     for entities that do not support it.
+
+    previews_preset_path:
+        type: str
+        default_value: "Generate Preview.xml"
+        description: Path to the preset to use to generate previews. If a relative path
+                     is passed, the path to the application specific presets for Shotgun will
+                     be prepended (/opt/Autodesk/presets/<version>/export/presets/shotgun/movie_file).
+                     This setting only apply from Flame 2019.1 and abve.
+
+
+    generate_local_movies:
+        type: bool
+        default_value: True
+        description: Generate an higher quality movies file that will not be uploaded to shotgun but
+                     can be used by client applications that do not want or cannot read original exported
+                     media from Flame.
+
+    local_movies_preset_path:
+        type: str
+        default_value: "Generate Local Movie.xml"
+        description: Path to the preset to use to generate local movies. If a relative path
+                     is passed, the path to the application specific presets for Shotgun will
+                     be prepended (/opt/Autodesk/presets/<version>/export/presets/shotgun/movie_file).
+                     This setting only apply from Flame 2019.1 and above.
+
+
+    bypass_server_transcoding:
+        description: Try to bypass the Shotgun server side transcoding for thumbnail generation if possible.
+                     This will upload the preview quicktime as is and will not generate a webm,
+                     meaning that playback will not be supported on all browsers.
+                     This will also disable playable movie preview and film strip generation.
+                     For more information about this option, please see the documentation.
+        type: bool
+        default_value: False
+
 
     use_builtin_plugin:
         type: bool

--- a/python/tk_flame/__init__.py
+++ b/python/tk_flame/__init__.py
@@ -1,12 +1,16 @@
-# Copyright (c) 2014 Shotgun Software Inc.
-# 
+# Copyright (c) 2018 Shotgun Software Inc.
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from .wiretap import WiretapHandler
-
+from .transcoder import Transcoder
+from .thumbnail_generator_ffmpeg import ThumbnailGeneratorFFmpeg
+from .thumbnail_generator_flame import ThumbnailGeneratorFlame
+from .local_movie_generator_ffmpeg import LocalMovieGeneratorFFmpeg
+from .local_movie_generator_flame import LocalMovieGeneratorFlame

--- a/python/tk_flame/local_movie_generator.py
+++ b/python/tk_flame/local_movie_generator.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2018 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Abstract interface of a local movie generator of Flame's exported assets.
+"""
+
+__all__ = ["LocalMovieGenerator"]
+
+class LocalMovieGenerator(object):
+    """
+    Abstract interface of a local movie generator of Flame's exported assets.
+    """
+
+    def __init__(self, engine):
+        self._engine = engine
+
+    @property
+    def engine(self):
+        """
+        :returns the DCC engine:
+        """
+        return self._engine
+
+    def generate(self, src_path, dst_path, display_name, target_entities, asset_info, dependencies):
+        """
+        Generate a local movie file from a Flame exported assets and link
+        it to a list of Shotgun entities in the Path to movie field.
+
+        :param src_path: Path to the media for which a local movie need to be
+            generated and linked to Shotgun.
+        :param dst_path: Path to local movie file to generate.
+        :param display_name: The display name of the item we are generating the
+            movie for. This will usually be the based name of the path.
+        :param target_entities: Target entities to which the movie need to
+            be linked to.
+        :param asset_info: Dictionary of attribute passed by Flame's python
+            hooks collected either thru an export (sg_export_hooks.py) or a
+            batch render (sg_batch_hooks.py).
+        :param dependencies: List of backburner job IDs this movie file
+            generation job need to wait in order to be started. Can be None if
+            the media is created in foreground.
+        """
+        if not self.engine.get_setting("generate_local_movies"):
+            return
+
+        (dst_path, job_id, files_to_delete) = self._generate(
+            src_path=src_path,
+            dst_path=dst_path,
+            display_name=display_name,
+            target_entities=target_entities,
+            asset_info=asset_info,
+            dependencies=dependencies
+        )
+
+        self.engine.create_local_backburner_job(
+            job_name="%s - Updating Shotgun Path to movie" % display_name,
+            description="Uploading Shotgun Path to movie to %s" % dst_path,
+            run_after_job_id=job_id,
+            instance="backburner_hooks",
+            method_name="update_path_to_movie",
+            args={
+                "targets": target_entities,
+                "path": dst_path,
+                "files_to_delete": files_to_delete
+            }
+        )
+
+    def _generate(self, src_path, dst_path, display_name, target_entities, asset_info, dependencies):
+        """
+        Implmentation of the generator. See generate() for details.
+        """
+        raise NotImplementedError

--- a/python/tk_flame/local_movie_generator_ffmpeg.py
+++ b/python/tk_flame/local_movie_generator_ffmpeg.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2018 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Local movie generator based on FFMpeg and read_frame.
+"""
+
+__all__ = ["LocalMovieGeneratorFFmpeg"]
+
+from .local_movie_generator import LocalMovieGenerator
+
+class LocalMovieGeneratorFFmpeg(LocalMovieGenerator):
+    """
+    Local movie generator based on FFMpeg and read_frame.
+    """
+
+    def __init__(self, engine):
+        super(LocalMovieGeneratorFFmpeg, self).__init__(engine)
+
+    def _generate(self, src_path, dst_path, display_name, target_entities, asset_info, dependencies):
+        """
+        Generate a thumbnail or a preview for a given media asset and link
+        it to a list of Shotgun entities. Multiple call to this method with
+        same path but different target_entitie can be done to bundle jobs.
+
+        :param src_path: Path to the media for which a local movie need to be generated and linked to Shotgun.
+        :param dst_path: Path to local movie file to generate.
+        :param display_name: The display name of the item we are generating the
+            movie for. This will usually be the based name of the path.
+        :param target_entities: Target entities to which the movie need to
+            be linked to.
+        :param asset_info: Dictionary of attribute passed by Flame's python
+            hooks collected either thru an export (sg_export_hooks.py) or a
+            batch render (sg_batch_hooks.py).
+        :param dependencies: List of backburner job IDs this thumbnail
+            generation job need to wait in order to be started. Can be None if
+            the media is created in foreground.
+        """
+        raise NotImplementedError

--- a/python/tk_flame/local_movie_generator_flame.py
+++ b/python/tk_flame/local_movie_generator_flame.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2018 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Local movie generator of Flame's exported assets based on Flame export API.
+"""
+
+__all__ = ["LocalMovieGeneratorFlame"]
+
+import os
+
+from .local_movie_generator import LocalMovieGenerator
+
+class LocalMovieGeneratorFlame(LocalMovieGenerator):
+    """
+    Local movie generator of Flame's exported assets based on Flame export API.
+    """
+
+    def __init__(self, engine):
+        super(LocalMovieGeneratorFlame, self).__init__(engine)
+
+    def _generate(self, src_path, dst_path, display_name, target_entities, asset_info, dependencies):
+        """
+        Generate a local movie file from a Flame exported assets and link
+        it to a list of Shotgun entities in the Path to movie field.
+
+        :param src_path: Path to the media for which a local movie need to be
+            generated and linked to Shotgun.
+        :param dst_path: Path to local movie file to generate.
+        :param display_name: The display name of the item we are generating the
+            movie for. This will usually be the based name of the path.
+        :param target_entities: Target entities to which the movie need to
+            be linked to.
+        :param asset_info: Dictionary of attribute passed by Flame's python
+            hooks collected either thru an export (sg_export_hooks.py) or a
+            batch render (sg_batch_hooks.py).
+        :param dependencies: List of backburner job IDs this movie file
+            generation job need to wait in order to be started. Can be None if
+            the media is created in foreground.
+        """
+        return self.engine.transcoder.transcode(
+            src_path=src_path,
+            dst_path=dst_path,
+            extension=os.path.splitext(dst_path)[-1],
+            display_name=display_name,
+            job_context="Create Shotgun Local Movie",
+            preset_path=self.engine.local_movies_preset_path,
+            asset_info=asset_info,
+            dependencies=dependencies,
+            poster_frame=None
+        )

--- a/python/tk_flame/project_create_dialog.py
+++ b/python/tk_flame/project_create_dialog.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2014 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import sgtk
@@ -17,51 +17,51 @@ class ProjectCreateDialog(QtGui.QWidget):
     """
     Project setup dialog for Flame
     """
-    
+
     # map the tab indices in the UI to constants
     (TAB_GENERAL, TAB_RESOLUTION, TAB_OLD_PROXY, TAB_NEW_PROXY) = range(4)
-    
-    def __init__(self, 
-                 project_name, 
-                 user_name, 
-                 workspace_name, 
-                 default_volume_name, 
-                 volume_names, 
-                 host_name, 
+
+    def __init__(self,
+                 project_name,
+                 user_name,
+                 workspace_name,
+                 default_volume_name,
+                 volume_names,
+                 host_name,
                  default_group_name,
                  group_names,
                  project_settings):
 
         """
         Constructor
-        
+
         :param project_name: Name of the project as string
         :param user_name: Name of the user as string
         :param workspace_name: Name of the workspace as string, None if default workspace should be used
         :param default_volume_name: The default volume name, as string
         :param volume_names: All available volumes, list of strings
         :param host_name: The host name to create the project on (str)
-        :param project_settings: Project settings. Dictionary as returned by 
+        :param project_settings: Project settings. Dictionary as returned by
                                  the project_startup_hook's get_project_settings method
         """
         # first, call the base class and let it do its thing.
         QtGui.QWidget.__init__(self)
-        
+
         self._engine = sgtk.platform.current_bundle()
-        
+
         # now load in the UI that was created in the UI designer
         self.ui = Ui_ProjectCreateDialog()
-        self.ui.setupUi(self) 
-        
-        # with the tk dialogs, we need to hook up our modal 
+        self.ui.setupUi(self)
+
+        # with the tk dialogs, we need to hook up our modal
         # dialog signals in a special way
         self.__exit_code = QtGui.QDialog.Rejected
         self.ui.create_project.clicked.connect(self._on_submit_clicked)
         self.ui.abort.clicked.connect(self._on_abort_clicked)
-        
+
         # set up callbacks
         self.ui.help_link.linkActivated.connect(self._on_help_url_clicked)
-        
+
         # populate fixed fields (the first tab)
         self.ui.project_name.setText(project_name)
         self.ui.setup_dir.setPlaceholderText("<default>")
@@ -71,7 +71,7 @@ class ProjectCreateDialog(QtGui.QWidget):
         else:
             self.ui.workspace_name.setText("Will use a Flame Default Workspace")
         self.ui.host_name.setText(host_name)
-        
+
         # populate storage volume dropdown
         self.ui.volume.addItems(volume_names)
         # now select the default value in combo box
@@ -92,11 +92,11 @@ class ProjectCreateDialog(QtGui.QWidget):
 
         # populate the resolution tab
         self.__populate_resolution_tab(project_settings)
-                
+
         # populate proxy tab
         if self._engine.is_version_less_than("2016.1"):
             # hide new-style settings tab
-            self.ui.tabWidget.removeTab(self.TAB_NEW_PROXY)            
+            self.ui.tabWidget.removeTab(self.TAB_NEW_PROXY)
             # init old-style settings tab
             self.__set_up_old_proxy_tab(project_settings)
         else:
@@ -107,10 +107,10 @@ class ProjectCreateDialog(QtGui.QWidget):
 
     def __populate_resolution_tab(self, project_settings):
         """
-        Populate the resolution UI tab with values from 
+        Populate the resolution UI tab with values from
         the given project settings dictionary
-        
-        :param project_settings: Dictionary as returned by 
+
+        :param project_settings: Dictionary as returned by
                                  the project_startup_hook's get_project_settings method
         """
         # populate the resolution tab
@@ -120,9 +120,9 @@ class ProjectCreateDialog(QtGui.QWidget):
         self.__set_combo_value(project_settings, self.ui.depth, "FrameDepth")
         self.__set_combo_value(project_settings, self.ui.field_dominance, "FieldDominance")
         self.__set_combo_value(project_settings, self.ui.frame_rate, "FrameRate")
-        
+
         aspect_ratio = project_settings.get("AspectRatio")
-        
+
         # aspect ratio: ["4:3", "16:9", "Based on width/height"]
         if aspect_ratio == "1.7778":
             self.ui.aspect_ratio.setCurrentIndex(1)
@@ -131,37 +131,37 @@ class ProjectCreateDialog(QtGui.QWidget):
         else:
             # use width/height aspect ratio
             self.ui.aspect_ratio.setCurrentIndex(2)
-        
+
     def __set_up_old_proxy_tab(self, project_settings):
         """
-        Populate the proxy UI tab with values from 
+        Populate the proxy UI tab with values from
         the given project settings dictionary. This method is for
         flame versions 2016.0 and below.
-        
-        :param project_settings: Dictionary as returned by 
+
+        :param project_settings: Dictionary as returned by
                                  the project_startup_hook's get_project_settings method
         """
         # set up signals for interaction
         self.ui.proxy_width_hint.valueChanged.connect(self._on_proxy_width_hint_change)
         self.ui.proxy_min_frame_size.valueChanged.connect(self._on_proxy_min_frame_size_change)
         self.ui.proxy_mode.currentIndexChanged.connect(self._on_proxy_mode_change)
-        
+
         enable_proxy = project_settings.get("ProxyEnable") == "true"
         proxy_min_frame_size = int(project_settings.get("ProxyMinFrameSize") or 0)
-        
+
         # first reset the combo to trigger the change events later
         self.ui.proxy_mode.setCurrentIndex(-1)
-        
+
         if enable_proxy == False and proxy_min_frame_size == 0:
             self.ui.proxy_mode.setCurrentIndex(0) # off
         elif enable_proxy == False and proxy_min_frame_size > 0:
-            self.ui.proxy_mode.setCurrentIndex(1) # conditionally 
+            self.ui.proxy_mode.setCurrentIndex(1) # conditionally
         else:
             self.ui.proxy_mode.setCurrentIndex(2) # on
-           
+
         self.__set_combo_value(project_settings, self.ui.proxy_depth, "ProxyDepthMode")
         self.__set_combo_value(project_settings, self.ui.proxy_quality, "ProxyQuality")
-        
+
         if project_settings.get("ProxyAbove8bits") == "true":
             self.ui.proxy_above_8_bits.setChecked(True)
         else:
@@ -169,50 +169,50 @@ class ProjectCreateDialog(QtGui.QWidget):
 
         pmfs = int(project_settings.get("ProxyMinFrameSize"))
         pwh = int(project_settings.get("ProxyWidthHint"))
-        
+
         self.ui.proxy_width_hint.setValue(pwh)
         self.ui.proxy_min_frame_size.setValue(pmfs)
-        
-        
+
+
     def __set_up_new_proxy_tab(self, project_settings):
         """
-        Populate the proxy UI tab with values from 
+        Populate the proxy UI tab with values from
         the given project settings dictionary. This method is for
         flame versions 2016.1 and above
-        
-        :param project_settings: Dictionary as returned by 
+
+        :param project_settings: Dictionary as returned by
                                  the project_startup_hook's get_project_settings method
-        """        
+        """
         # set the quality combo
         self.__set_combo_value(project_settings, self.ui.new_proxy_quality, "ProxyQuality")
-        
+
         # set the checkbox
         if project_settings.get("ProxyRegenState") == "true":
             self.ui.new_generate_proxies.setChecked(True)
         else:
             self.ui.new_generate_proxies.setChecked(False)
-        
+
         # set the minimum size slider
         proxy_min_frame_size = int(project_settings.get("ProxyMinFrameSize") or 0)
         self.ui.new_proxy_width.setValue(proxy_min_frame_size)
 
-        # figure out the mode setting - this is driven by the ProxyWidth setting 
+        # figure out the mode setting - this is driven by the ProxyWidth setting
         proxy_width = float(project_settings.get("ProxyWidthHint") or 0.0)
-        
+
         if proxy_width == 0.5:
             combo_index = self.ui.new_proxy_mode.findText("Proxy 1/2")
-            
+
         elif proxy_width == 0.25:
             combo_index = self.ui.new_proxy_mode.findText("Proxy 1/4")
 
         elif proxy_width == 0.125:
             combo_index = self.ui.new_proxy_mode.findText("Proxy 1/8")
-            
+
         else:
-            combo_index = self.ui.new_proxy_mode.findText("Proxy 1/2")            
+            combo_index = self.ui.new_proxy_mode.findText("Proxy 1/2")
 
         self.ui.new_proxy_mode.setCurrentIndex(combo_index)
-        
+
     def __set_combo_value(self, project_settings, combo_widget, setting):
         """
         Helper method.
@@ -225,11 +225,11 @@ class ProjectCreateDialog(QtGui.QWidget):
         else:
             idx = combo_widget.findText(str(value))
             combo_widget.setCurrentIndex(idx)
-         
+
     def get_volume_name(self):
         """
         Returns the selected storage volume
-        
+
         :returns: volume as string
         """
         return str(self.ui.volume.currentText())
@@ -237,22 +237,22 @@ class ProjectCreateDialog(QtGui.QWidget):
     def get_group_name(self):
         """
         Returns the selected group
-        
+
         :returns: group as string
         """
         return str(self.ui.group_name.currentText())
-         
+
     def get_settings(self):
         """
         Returns a settings dictionary, on the following form:
-        
+
          - FrameWidth (e.g. "1280")
          - FrameHeight (e.g. "1080")
-         - FrameDepth (16-bit fp, 12-bit, 12-bit u, 10-bit, 8-bit) 
+         - FrameDepth (16-bit fp, 12-bit, 12-bit u, 10-bit, 8-bit)
          - FrameRate (23.976, 24, 25, 29.97 df, 29.97 ndf, 30, 50, 50.94 df, 50.94 ndf, 60)
          - FieldDominance (PROGRESSIVE, FIELD_1, FIELD_2)
          - AspectRatio (4:3, 16:9, or floating point value as string)
-         
+
          - ProxyEnable ("true" or "false")
          - ProxyWidthHint
          - ProxyDepthMode
@@ -260,10 +260,10 @@ class ProjectCreateDialog(QtGui.QWidget):
          - ProxyAbove8bits ("true" or "false")
          - ProxyQuality
          - ProxyRegenState
-         - ProxyDepth         
+         - ProxyDepth
         """
         settings = {}
-        
+
         setup_dir = self.ui.setup_dir.text().strip()
         if setup_dir:
             settings["SetupDir"] = setup_dir
@@ -272,23 +272,22 @@ class ProjectCreateDialog(QtGui.QWidget):
         settings["FrameDepth"] = self.ui.depth.currentText()
         settings["FieldDominance"] = self.ui.field_dominance.currentText()
         settings["FrameRate"] = self.ui.frame_rate.currentText()
-        
+
         # aspect ratio: ["4:3", "16:9", "Based on width/height"]
-        
+
         if self.ui.aspect_ratio.currentIndex() == 0:
             settings["AspectRatio"] = "1.33333"
         elif self.ui.aspect_ratio.currentIndex() == 1:
             settings["AspectRatio"] = "1.777778"
         else:
             settings["AspectRatio"] = "%4f" % (float(settings["FrameWidth"]) / float(settings["FrameHeight"]))
-        
 
-        if self._engine.is_version_less_than("2016.1"):        
+        if self._engine.is_version_less_than("2016.1"):
             # old proxy settings
             if self.ui.proxy_mode.currentIndex() == 0:
                 settings["ProxyEnable"] = "false"
                 settings["ProxyWidthHint"] = "0"
-                
+
             elif self.ui.proxy_mode.currentIndex() == 1:
                 settings["ProxyEnable"] = "false"
                 settings["ProxyWidthHint"] = "%s" % self.ui.proxy_width_hint.value()
@@ -296,7 +295,7 @@ class ProjectCreateDialog(QtGui.QWidget):
                 settings["ProxyMinFrameSize"] = "%s" % self.ui.proxy_min_frame_size.value()
                 settings["ProxyAbove8bits"] = "true" if self.ui.proxy_above_8_bits.isChecked() else "false"
                 settings["ProxyQuality"] = self.ui.proxy_quality.currentText()
-            
+
             else:
                 settings["ProxyEnable"] = "true"
                 settings["ProxyWidthHint"] = "%s" % self.ui.proxy_width_hint.value()
@@ -310,42 +309,42 @@ class ProjectCreateDialog(QtGui.QWidget):
             settings["ProxyRegenState"] = "true" if self.ui.new_generate_proxies.isChecked() else "false"
             settings["ProxyQuality"] = self.ui.new_proxy_quality.currentText()
             settings["ProxyMinFrameSize"] = "%s" % self.ui.new_proxy_width.value()
-            
+
             # the ProxyWidthHint is derived from the 1/2, 1/4, 1/8 settings and the width
             if self.ui.new_proxy_mode.currentText() == "Proxy 1/2":
                 settings["ProxyWidthHint"] = "0.5"
-            
+
             elif self.ui.new_proxy_mode.currentText() == "Proxy 1/4":
                 settings["ProxyWidthHint"] = "0.25"
-            
+
             elif self.ui.new_proxy_mode.currentText() == "Proxy 1/8":
                 settings["ProxyWidthHint"] = "0.125"
-                
+
         return settings
-        
+
     @property
     def exit_code(self):
         """
         Used to pass exit code back though sgtk dialog
-        
+
         :returns:    The dialog exit code
         """
         return self.__exit_code
-                
+
     @property
     def hide_tk_title_bar(self):
         """
         Tell the system to not show the std toolbar
         """
         return True
-                
+
     def _on_submit_clicked(self):
         """
         Called when the 'submit' button is clicked.
         """
         self.__exit_code = QtGui.QDialog.Accepted
         self.close()
-        
+
     def _on_abort_clicked(self):
         """
         Called when the 'cancel' button is clicked.
@@ -372,21 +371,21 @@ class ProjectCreateDialog(QtGui.QWidget):
         self.ui.proxy_width_hint_preview.setText("%s px" % val)
         # min frame size value must be greater or equal to this value
         self.ui.proxy_min_frame_size.setMinimum(val)
-        
+
     def _on_proxy_min_frame_size_change(self):
         """
         Update slider preview for proxy min size
         """
         val = self.ui.proxy_min_frame_size.value()
         self.ui.proxy_min_frame_size_preview.setText("%d px" % val)
-        
+
     def _on_proxy_mode_change(self, idx):
         """
-        Proxy enabled clicked. Enable/disable a bunch 
+        Proxy enabled clicked. Enable/disable a bunch
         of fields based on the value.
         """
         # [off, conditional, on]
-        
+
         # first turn off everything
         self.ui.proxy_depth.setVisible(False)
         self.ui.proxy_quality.setVisible(False)
@@ -395,12 +394,12 @@ class ProjectCreateDialog(QtGui.QWidget):
         self.ui.proxy_depth_label.setVisible(False)
         self.ui.proxy_quality_label.setVisible(False)
         self.ui.proxy_width_hint_label.setVisible(False)
-        
+
         self.ui.proxy_min_frame_size.setVisible(False)
         self.ui.proxy_min_frame_size_preview.setVisible(False)
         self.ui.proxy_above_8_bits.setVisible(False)
         self.ui.proxy_min_frame_size_label.setVisible(False)
-        
+
         if idx > 0:
             # on / conditional
             self.ui.proxy_depth.setVisible(True)
@@ -410,11 +409,10 @@ class ProjectCreateDialog(QtGui.QWidget):
             self.ui.proxy_depth_label.setVisible(True)
             self.ui.proxy_quality_label.setVisible(True)
             self.ui.proxy_width_hint_label.setVisible(True)
-            
+
         if idx == 1:
             # conditional
             self.ui.proxy_min_frame_size.setVisible(True)
             self.ui.proxy_min_frame_size_preview.setVisible(True)
             self.ui.proxy_above_8_bits.setVisible(True)
             self.ui.proxy_min_frame_size_label.setVisible(True)
-        

--- a/python/tk_flame/thumbnail_generator.py
+++ b/python/tk_flame/thumbnail_generator.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2018 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+__all__ = ["ThumbnailGenerator"]
+
+class ThumbnailGenerator(object):
+    """
+    Abstract interface of a thumbnail generator of Flame's exported assets.
+    """
+
+    def __init__(self, engine):
+        self._engine = engine
+
+    @property
+    def engine(self):
+        """
+        :returns the DCC engine:
+        """
+        return self._engine
+
+    @staticmethod
+    def _does_entity_support_preview(entity):
+        """
+        Returns True if the entity support movie preview
+        :returns boolean:
+        """
+        return entity.get("type") == "Version"
+
+    def generate(self, path, display_name, target_entities, asset_info, dependencies, favor_preview=True):
+        """
+        Generate a thumbnail or a preview for a given media asset and link
+        it to a list of Shotgun entities. Multiple call to this method with
+        same path but different target_entitie can be done to bundle jobs.
+
+        :param path: Path to the media for which thumbnail or preview need to be
+            generated and uploaded to Shotgun.
+        :param display_name: The display name of the item we are generating the
+            thumbnail for. This will usually be the based name of the path.
+        :param target_entities: Target entities to which the thumbnails need to
+            be linked to.
+        :param asset_info: Dictionary of attribute passed by Flame's python
+            hooks collected either thru an export (sg_export_hooks.py) or a
+            batch render (sg_batch_hooks.py).
+        :param dependencies: List of backburner job IDs this thumbnail
+            generation job need to wait in order to be started. Can be None if
+            the media is created in foreground.
+        :param favor_preview: Movie previews will be favored over static
+            thumbnails if the entity supports it.
+        """
+
+        # Split target entities in two groups, the ones that support movies
+        # and the ones that dont since uploading a movie will generate also
+        # a thumbnail
+        bypass_server_transcoding = self.engine.get_setting("bypass_server_transcoding")
+        if bypass_server_transcoding:
+            self.engine.log_debug("Bypass Shotgun transcoding setting ENABLED.")
+
+        generate_previews = favor_preview and self.engine.get_setting("generate_previews")
+        if not generate_previews:
+            self.engine.log_debug("Generation of preview DISABLED.")
+
+        generate_thumbnails = self.engine.get_setting("generate_thumbnails")
+        if not generate_thumbnails:
+            self.engine.log_debug("Generation of thumbnail DISABLED.")
+
+        preview_entities = []
+        thumbnail_entities = []
+        for target_entity in target_entities:
+            if generate_previews and self._does_entity_support_preview(target_entity):
+                preview_entities.append(target_entity)
+
+                # Since the uploaded movie will not generate a thumbnail,
+                # we need to upload a thumbnail too.
+                if bypass_server_transcoding and generate_thumbnails:
+                    thumbnail_entities.append(target_entity)
+            elif generate_thumbnails:
+                thumbnail_entities.append(target_entity)
+
+        if len(preview_entities) > 0:
+            self._generate_preview(
+                path=path,
+                display_name=display_name,
+                target_entities=preview_entities,
+                asset_info=asset_info,
+                dependencies=dependencies
+            )
+
+        if len(thumbnail_entities) > 0:
+            self._generate_thumbnail(
+                path=path,
+                display_name=display_name,
+                target_entities=thumbnail_entities,
+                asset_info=asset_info,
+                dependencies=dependencies
+            )
+
+    def _generate_preview(self, path, display_name, target_entities, asset_info, dependencies):
+        """
+        Generate a preview for a given media asset and link
+        it to a list of Shotgun entities. Multiple call to this method with
+        same path but different target_entitie can be done to bundle jobs.
+
+        :param path: Path to the media for which thumbnail or preview need to be
+            generated and uploaded to Shotgun.
+        :param display_name: The display name of the item we are generating the
+            thumbnail for. This will usually be the based name of the path.
+        :param target_entities: Target entities to which the thumbnails need to
+            be linked to.
+        :param asset_info: Dictionary of attribute passed by Flame's python
+            hooks collected either thru an export (sg_export_hooks.py) or a
+            batch render (sg_batch_hooks.py).
+        :param dependencies: List of backburner job IDs this thumbnail
+            generation job need to wait in order to be started. Can be None if
+            the media is created in foreground.
+        """
+        raise NotImplementedError
+
+    def _generate_thumbnail(self, path, display_name, target_entities, asset_info, dependencies):
+        """
+        Generate a thumbnail for a given media asset and link
+        it to a list of Shotgun entities. Multiple call to this method with
+        same path but different target_entitie can be done to bundle jobs.
+
+        :param path: Path to the media for which thumbnail or preview need to be
+            generated and uploaded to Shotgun.
+        :param display_name: The display name of the item we are generating the
+            thumbnail for. This will usually be the based name of the path.
+        :param target_entities: Target entities to which the thumbnails need to
+            be linked to.
+        :param asset_info: Dictionary of attribute passed by Flame's python
+            hooks collected either thru an export (sg_export_hooks.py) or a
+            batch render (sg_batch_hooks.py).
+        :param dependencies: List of backburner job IDs this thumbnail
+            generation job need to wait in order to be started. Can be None if
+            the media is created in foreground.
+        """
+        raise NotImplementedError
+
+    def finalize(self, path=None):
+        """
+        Ensure the generated thumbnail or preview have been uploaded to the
+        Shotgun Server if that was not done during the generate() pass.
+
+        :param path: Path to the media for which thumbnail or/and preview need
+            to be uploaded to Shotgun. If None is pass, all jobs will be
+            finalized.
+        """
+        raise NotImplementedError

--- a/python/tk_flame/thumbnail_generator_ffmpeg.py
+++ b/python/tk_flame/thumbnail_generator_ffmpeg.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2018 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Thumbnail generator based on FFmpeg and read_frame.
+"""
+
+__all__ = ["ThumbnailGeneratorFFmpeg"]
+
+from .thumbnail_generator import ThumbnailGenerator
+
+class ThumbnailGeneratorFFmpeg(ThumbnailGenerator):
+
+    def __init__(self, engine):
+        super(ThumbnailGeneratorFFmpeg, self).__init__(engine)
+
+    """
+    Thumbnail generator based on ffmpeg and read_frame.
+    """
+    def _generate_preview(self, path, display_name, target_entities, asset_info, dependencies):
+        """
+        Generate a preview for a given media asset and link
+        it to a list of Shotgun entities. Multiple call to this method with
+        same path but different target_entitie can be done to bundle jobs.
+
+        :param path: Path to the media for which thumbnail or preview need to be
+            generated and uploaded to Shotgun.
+        :param display_name: The display name of the item we are generating the
+            thumbnail for. This will usually be the based name of the path.
+        :param target_entities: Target entities to which the thumbnails need to
+            be linked to.
+        :param asset_info: Dictionary of attribute passed by Flame's python
+            hooks collected either thru an export (sg_export_hooks.py) or a
+            batch render (sg_batch_hooks.py).
+        :param dependencies: List of backburner job IDs this thumbnail
+            generation job need to wait in order to be started. Can be None if
+            the media is created in foreground.
+        """
+        self.engine.log_debug("Create and Upload Preview using ffmpeg")
+        self.engine.create_local_backburner_job(
+            "%s - Create and Upload Thumbnail" % display_name,
+            "Create and Upload Shotgun Thumbnail for %s - %s" % (display_name, path),
+            ",".join(dependencies) if dependencies else None,
+            "backburner_hooks",
+            "attach_mov_preview",
+            {
+                "targets": target_entities,
+                "width": asset_info["width"],
+                "height": asset_info["height"],
+                "path": path,
+                "display_name": display_name,
+                "fps": asset_info["fps"]
+            }
+        )
+
+    def _generate_thumbnail(self, path, display_name, target_entities, asset_info, dependencies):
+        """
+        Generate a thumbnail for a given media asset and link
+        it to a list of Shotgun entities. Multiple call to this method with
+        same path but different target_entitie can be done to bundle jobs.
+
+        :param path: Path to the media for which thumbnail or preview need to be
+            generated and uploaded to Shotgun.
+        :param display_name: The display name of the item we are generating the
+            thumbnail for. This will usually be the based name of the path.
+        :param target_entities: Target entities to which the thumbnails need to
+            be linked to.
+        :param asset_info: Dictionary of attribute passed by Flame's python
+            hooks collected either thru an export (sg_export_hooks.py) or a
+            batch render (sg_batch_hooks.py).
+        :param dependencies: List of backburner job IDs this thumbnail
+            generation job need to wait in order to be started. Can be None if
+            the media is created in foreground.
+        """
+        self.engine.log_debug("Create and Upload thumnail using read_frame")
+        self.engine.create_local_backburner_job(
+            "%s - Create and Upload Thumbnail" % display_name,
+            "Create and Upload Shotgun Thumbnail for %s - %s" % (display_name, path),
+            ",".join(dependencies) if dependencies else None,
+            "backburner_hooks",
+            "attach_jpg_preview",
+            {
+                "targets": target_entities,
+                "width": asset_info["width"],
+                "height": asset_info["height"],
+                "path": path,
+                "display_name": display_name
+            }
+        )
+
+    def finalize(self, path=None):
+        """
+        Ensure the generated thumbnail or preview have been uploaded to the
+        Shotgun Server if that was not done during the generate() pass.
+
+        :param path: Path to the media for which thumbnail or/and preview need
+            to be uploaded to Shotgun. If None is pass, all jobs will be
+            finalized.
+        """
+        pass

--- a/python/tk_flame/thumbnail_generator_flame.py
+++ b/python/tk_flame/thumbnail_generator_flame.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2018 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Thumbnail generator based on Flame export API.
+"""
+
+__all__ = ["ThumbnailGeneratorFlame"]
+
+from .thumbnail_generator import ThumbnailGenerator
+
+class ThumbnailGeneratorFlame(ThumbnailGenerator):
+    """
+    Thumbnail generator based on Flame export API
+    """
+
+    def __init__(self, engine):
+        super(ThumbnailGeneratorFlame, self).__init__(engine)
+        self._preview_jobs = {}
+        self._thumbnail_jobs = {}
+
+    def _generate_preview(self, path, display_name, target_entities, asset_info, dependencies):
+        """
+        Generate a preview for a given media asset and link
+        it to a list of Shotgun entities. Multiple call to this method with
+        same path but different target_entitie can be done to bundle jobs.
+
+        :param path: Path to the media for which thumbnail or preview need to be
+            generated and uploaded to Shotgun.
+        :param display_name: The display name of the item we are generating the
+            thumbnail for. This will usually be the based name of the path.
+        :param target_entities: Target entities to which the thumbnails need to
+            be linked to.
+        :param asset_info: Dictionary of attribute passed by Flame's python
+            hooks collected either thru an export (sg_export_hooks.py) or a
+            batch render (sg_batch_hooks.py).
+        :param dependencies: List of backburner job IDs this thumbnail
+            generation job need to wait in order to be started. Can be None if
+            the media is created in foreground.
+        """
+
+        preview_job = self._preview_jobs.get(path, None)
+        if preview_job is None:
+            self.engine.log_debug("Create and Upload Preview using Flame exporter")
+
+            (dst_path, job_id, files_to_delete) = self.engine.transcoder.transcode(
+                src_path=path,
+                dst_path=None,
+                extension=".mov",
+                display_name=display_name,
+                job_context="Create Shotgun Preview",
+                preset_path=self.engine.previews_preset_path,
+                asset_info=asset_info,
+                dependencies=dependencies,
+                poster_frame=None
+            )
+
+            self._preview_jobs[path] = {
+                "display_name": display_name,
+                "dependencies": job_id,
+                "target_entities": target_entities,
+                "path": dst_path,
+                "files_to_delete": files_to_delete
+            }
+        else:
+            preview_job["target_entities"] = preview_job["target_entities"] + target_entities
+
+    def _generate_thumbnail(self, path, display_name, target_entities, asset_info, dependencies):
+        """
+        Generate a thumbnail for a given media asset and link
+        it to a list of Shotgun entities. Multiple call to this method with
+        same path but different target_entitie can be done to bundle jobs.
+
+        :param path: Path to the media for which thumbnail or preview need to be
+            generated and uploaded to Shotgun.
+        :param display_name: The display name of the item we are generating the
+            thumbnail for. This will usually be the based name of the path.
+        :param target_entities: Target entities to which the thumbnails need to
+            be linked to.
+        :param asset_info: Dictionary of attribute passed by Flame's python
+            hooks collected either thru an export (sg_export_hooks.py) or a
+            batch render (sg_batch_hooks.py).
+        :param dependencies: List of backburner job IDs this thumbnail
+            generation job need to wait in order to be started. Can be None if
+            the media is created in foreground.
+        """
+        thumbnail_job = self._thumbnail_jobs.get(path, None)
+        if thumbnail_job is None:
+            self.engine.log_debug("Create and Upload Thumbnail using Flame exporter")
+
+            # FIXME we should use the poster frame index supplied by Flame.
+            poster_frame = 1
+
+            (dst_path, job_id, files_to_delete) = self.engine.transcoder.transcode(
+                src_path=path,
+                dst_path=None,
+                extension=".jpg",
+                display_name=display_name,
+                job_context="Create Shotgun Thumbnail",
+                preset_path=self.engine.thumbnails_preset_path,
+                asset_info=asset_info,
+                dependencies=dependencies,
+                poster_frame=poster_frame
+            )
+
+            self._thumbnail_jobs[path] = {
+                "display_name": display_name,
+                "dependencies": job_id,
+                "target_entities": target_entities,
+                "path": dst_path,
+                "files_to_delete": files_to_delete
+            }
+        else:
+            thumbnail_job["target_entities"] = thumbnail_job["target_entities"] + target_entities
+
+    def _upload_thumbnail_job(self, thumbnail_job):
+        self.engine.create_local_backburner_job(
+            job_name="%s - Uploading Shotgun Thumbnail" % thumbnail_job.get("display_name"),
+            description="Uploading Shotgun Thumbnail for %s" % thumbnail_job.get("path"),
+            run_after_job_id=thumbnail_job.get("dependencies"),
+            instance="backburner_hooks",
+            method_name="upload_to_shotgun",
+            args={
+                "targets": thumbnail_job.get("target_entities"),
+                "path": thumbnail_job.get("path"),
+                "field_name": "thumb_image",
+                "display_name": thumbnail_job.get("display_name"),
+                "files_to_delete": thumbnail_job.get("files_to_delete")
+            }
+        )
+
+    def _upload_preview_job(self, preview_job):
+        if self.engine.get_setting("bypass_server_transcoding"):
+            self.engine.log_debug("Bypass Shotgun transcoding setting ENABLED.")
+            field_name = "sg_uploaded_movie_mp4"
+        else:
+            field_name = "sg_uploaded_movie"
+
+        self.engine.create_local_backburner_job(
+            job_name="%s - Uploading Shotgun Preview" % preview_job.get("display_name"),
+            description="Uploading Shotgun Preview for %s" % preview_job.get("path"),
+            run_after_job_id=preview_job.get("dependencies"),
+            instance="backburner_hooks",
+            method_name="upload_to_shotgun",
+            args={
+                "targets": preview_job.get("target_entities"),
+                "path": preview_job.get("path"),
+                "field_name": field_name,
+                "display_name": preview_job.get("display_name"),
+                "files_to_delete": preview_job.get("files_to_delete")
+            }
+        )
+
+    def finalize(self, path=None):
+        """
+        Ensure the generated thumbnail or preview have been uploaded to the
+        Shotgun Server if that was not done during the generate() pass.
+
+        :param path: Path to the media for which thumbnail or/and preview need
+            to be uploaded to Shotgun. If None is pass, all jobs will be
+            finalized.
+        """
+
+        # A Given path can have both a thumbnail or a preview to upload since
+        # not all entity type support a preview upload
+
+        if path is not None:
+            thumbnail_job = self._thumbnail_jobs.pop(path, None)
+            if thumbnail_job is not None:
+                self._upload_thumbnail_job(thumbnail_job)
+
+            preview_job = self._preview_jobs.pop(path, None)
+            if preview_job is not None:
+                self._upload_preview_job(preview_job)
+        else:
+            for thumbnail_job in self._thumbnail_jobs.values():
+                self._upload_thumbnail_job(thumbnail_job)
+            self._thumbnail_jobs = {}
+
+            for preview_job in self._preview_jobs.values():
+                self._upload_preview_job(preview_job)
+            self.preview_jobs = {}

--- a/python/tk_flame/transcoder.py
+++ b/python/tk_flame/transcoder.py
@@ -1,0 +1,283 @@
+# Copyright (c) 2018 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+__all__ = ["Transcoder"]
+
+import os
+import tempfile
+
+from sgtk import TankError
+
+class Transcoder(object):
+    """
+    Thumbnail generator based on Flame export API
+    """
+
+    def __init__(self, engine):
+        self._engine = engine
+
+    @property
+    def engine(self):
+        """
+        :returns the DCC engine:
+        """
+        return self._engine
+
+    def _import_clip(self, path):
+        """
+        Imports a single clip at a given path.
+
+        :param path: Path to the media to import.
+        :returns clip: Flame's Python API clip object or none.
+        """
+        import flame
+        clips = flame.import_clips(path)
+        self.engine.log_debug("Imported '%s' -> [%s]" % (path, clips))
+        if len(clips) == 0:
+            self.engine.log_warning("%s does not points to a clip" % path)
+            return None
+        elif len(clips) > 1:
+            self.engine.log_warning("%s points to more than one clip." \
+                                    " First one will be used." % path)
+        return clips[0]
+
+    @staticmethod
+    def _build_python_hook_override(user_data_job_key):
+        """
+        Build a Flame's python hook override callback for export that will
+        prevent python hook to trigger a shotgun publish when generating the
+        thumbnails from the Flame's export API.
+
+        Also collect the background job create if any and flag that we want to
+        overwrite any media exported.
+
+        :param user_data_job_key: Key to use in userData for the background job
+            ID collected.
+        :returns PythonHookOverride: Python Hook override callback object.
+        """
+
+        class PythonHookOverride(object):
+            def __init__(self, user_data_job_key):
+                self._user_data_job_key = user_data_job_key
+
+            def preExport(self, info, userData, *args, **kwargs):
+                pass
+
+            def postExport(self, info, userData, *args, **kwargs):
+                pass
+
+            def preExportSequence(self, info, userData, *args, **kwargs):
+                pass
+
+            def postExportSequence(self, info, userData, *args, **kwargs):
+                pass
+
+            def preExportAsset(self, info, userData, *args, **kwargs):
+                pass
+
+            def postExportAsset(self, info, userData, *args, **kwargs):
+                userData[self._user_data_job_key] = info["backgroundJobId"]
+
+            def exportOverwriteFile(self, path, *args, **kwargs):
+                return "overwrite"
+        return PythonHookOverride(user_data_job_key)
+
+    def _create_temporary_file(self, extension, clip):
+        """
+        Create a temporary file and rename the clip to match to the file name
+        so the clip, once exported will overwrite that file.
+
+        :param extension: Extension of the temporary file created
+        :param clip: Flame's clip object we want to rename to match the
+            temporary file created.
+        :returns path: String of the path created.
+        """
+        (tmp_fd, path) = tempfile.mkstemp(
+            suffix=extension,
+            dir=self.engine.get_backburner_tmp())
+        os.close(tmp_fd)
+        clip.name = os.path.splitext(os.path.basename(path))[0]
+        return path
+
+    def _create_open_clip_file(self, src_path, asset_info):
+        """
+        Create an Open Clip file that points to the exported asset that can
+        be used to import the clip before it is actually finished exporting.
+
+        This can be used to schedule an export job depending on another export
+        job before the first one complete.
+
+        :param src_path: Path to the media for which transcoding need to be done.
+        :param asset_info: Dictionary of attribute passed by Flame's python
+            hooks collected either thru an export (sg_export_hooks.py) or a
+            batch render (sg_batch_hooks.py).
+
+        :returns path: String of the path created, None in case of error.
+        """
+        if asset_info["assetType"] not in ["video", "movie"]:
+            self.engine.log_error("Cannot create Open clip for non-video assets")
+            return None
+
+        (tmp_fd, path) = tempfile.mkstemp(
+            suffix=".clip",
+            dir=self.engine.get_backburner_tmp())
+
+        metadata = {}
+        metadata["path"] = src_path
+        metadata["height"] = asset_info["height"]
+        metadata["width"] = asset_info["width"]
+        channels_encoding = asset_info.get("channelsEncoding", None)
+        if channels_encoding is None:
+            channels_encoding = "Float" if "fp" in asset_info["depth"] else "Integer"
+        metadata["channelsEncoding"] = channels_encoding
+        metadata["channelsDepth"] = asset_info["depth"].replace("-bit", "").replace(" fp", "")
+        metadata["pixelLayout"] = asset_info.get("pixelLayout", "RGB")
+        metadata["nbChannels"] = len(metadata["pixelLayout"])
+        try:
+            metadata["pixelRatio"] = asset_info.get("aspectRatio", 1.0) \
+                                   * asset_info["height"] / asset_info["width"]
+        except ZeroDivisionError:
+            metadata["pixelRatio"] = 1.0
+
+        scan_format = asset_info.get("scanFormat", "PROGRESSIVE")
+        if scan_format == "FIELD_1":
+            metadata["fieldDominance"] = 0
+        if scan_format == "FIELD_2":
+            metadata["fieldDominance"] = 1
+        else: # PROGRESSIVE
+            metadata["fieldDominance"] = 2
+        metadata["colourSpace"] = asset_info.get("colourSpace", "Unknown")
+
+        os.write(
+            tmp_fd,
+            """
+            <clip type=\"clip\" version=\"4\">
+             <tracks type=\"tracks\">
+              <track type=\"track\" uid=\"t0\">
+               <trackType>video</trackType>
+               <feeds currentVersion=\"v0\">
+                <feed type=\"feed\" vuid=\"v0\" uid=\"v0\">
+                 <storageFormat type=\"format\">
+                  <type>video</type>
+                  <nbChannels type=\"uint\">{nbChannels}</nbChannels>
+                  <channelsDepth type=\"uint\">{channelsDepth}</channelsDepth>
+                  <channelsEncoding type=\"string\">{channelsEncoding}</channelsEncoding>
+                  <pixelLayout type=\"string\">{pixelLayout}</pixelLayout>
+                  <height type=\"uint\">{height}</height>
+                  <pixelRatio type=\"float\">{pixelRatio}</pixelRatio>
+                  <width type=\"uint\">{width}</width>
+                  <fieldDominance type=\"int\">{fieldDominance}</fieldDominance>
+                  <colourSpace type=\"string\">{colourSpace}</colourSpace>
+                 </storageFormat>
+                 <spans type=\"spans\">
+                  <span type=\"span\">
+                   <path encoding=\"pattern\">{path}</path>
+                  </span>
+                 </spans>
+                </feed>
+               </feeds>
+              </track>
+             </tracks>
+            </clip>""".format(**metadata))
+        os.close(tmp_fd)
+        return path
+
+    def transcode(self, src_path, dst_path, extension, display_name, job_context, preset_path, asset_info, dependencies, poster_frame=None):
+        """
+        Generate a preview for a given media asset and link
+        it to a list of Shotgun entities. Multiple call to this method with
+        same path but different target_entitie can be done to bundle jobs.
+
+        :param src_path: Path to the media for which transcoding need to be done.
+        :param dst_path: Path of the trancoded media.
+        :param display_name: The display name of the item we are generating the
+            thumbnail for. This will usually be the based name of the path.
+        :param preset_path: The path to the preset to use to export the movie file.
+        :param asset_info: Dictionary of attribute passed by Flame's python
+            hooks collected either thru an export (sg_export_hooks.py) or a
+            batch render (sg_batch_hooks.py).
+        :param dependencies: List of backburner job IDs this thumbnail
+            generation job need to wait in order to be started. Can be None if
+            the media is created in foreground.
+        """
+
+        import flame
+        temp_files = []
+
+        # If we depend on a backburner jobs we cannot reimport the exported
+        # media until it finished exporting, however we would like to send the
+        # transcoding job before that happen. We can however create an Open Clip
+        # file that point to the exported media location with the matching
+        # metadata and import it. Reading the frames on that Open Clip would
+        # fail before the original export job is finished but since the thumbnail
+        # transcoding job depend on it, it will be fine by then.
+        #
+        if dependencies is not None:
+            if os.path.splitext(src_path)[-1].lower() != ".clip":
+                path_to_import = self._create_open_clip_file(
+                    src_path=src_path,
+                    asset_info=asset_info
+                )
+                temp_files.append(path_to_import)
+            else:
+                path_to_import = src_path
+        else:
+            path_to_import = src_path
+        clip = self._import_clip(path=path_to_import)
+        if clip is None:
+            raise TankError(
+                "%s cannot be imported to be transcoded." % path_to_import
+            )
+
+
+        if dst_path is None:
+            actual_dst_path = self._create_temporary_file(
+                extension=extension,
+                clip=clip
+            )
+            temp_files.append(actual_dst_path)
+        else:
+            actual_dst_path = dst_path
+
+        exporter = flame.PyExporter()
+        exporter.foreground_export = False
+
+        # FIXME this will work only if out_mark is exclusive which is the default.
+        if poster_frame is not None:
+            clip.in_mark = poster_frame
+            clip.out_mark = poster_frame + 1
+            exporter.export_between_marks = True
+
+        self.engine.log_debug("Exporting using preset '%s' to '%s' depending on '%s'" % \
+                              (preset_path, actual_dst_path, dependencies))
+
+        background_job_settings = flame.PyExporter.BackgroundJobSettings()
+        background_job_settings.name = "%s - %s" % (
+            display_name,
+            job_context
+        )
+        background_job_settings.description = "%s for %s - %s -> %s" % (
+            job_context,
+            display_name,
+            src_path,
+            dst_path
+        )
+        background_job_settings.dependencies = dependencies
+
+        hooks_user_data = {}
+        transcoder_job_key = "transcoder_job"
+        exporter.export(
+            sources=clip,
+            preset_path=preset_path,
+            output_directory=self.engine.get_backburner_tmp(),
+            background_job_settings=background_job_settings,
+            hooks=self._build_python_hook_override(transcoder_job_key),
+            hooks_user_data=hooks_user_data)
+        return (actual_dst_path, hooks_user_data.get(transcoder_job_key), temp_files)

--- a/python/tk_flame/ui/__init__.py
+++ b/python/tk_flame/ui/__init__.py
@@ -1,10 +1,9 @@
 # Copyright (c) 2014 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
-

--- a/python/tk_flame/wiretap.py
+++ b/python/tk_flame/wiretap.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2014 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
@@ -39,137 +39,135 @@ class WiretapError(TankError):
     pass
 
 # note: this is one of those C style library wrappers
-# where each method internally is prefixed with 
+# where each method internally is prefixed with
 # WireTap, hence the dropping of the namespace.
 from libwiretapPythonClientAPI import *
 
-from .project_create_dialog import ProjectCreateDialog 
+from .project_create_dialog import ProjectCreateDialog
 from .qt_task import start_qt_app_and_show_modal
 
 class WiretapHandler(object):
     """
     Wiretap functionality
     """
-    
+
     #########################################################################################################
     # public methods
-    
+
     def __init__(self):
         """
         Construction
         """
         self._engine = sgtk.platform.current_bundle()
-        
+
         self._engine.log_debug("Initializing wiretap...")
         WireTapClientInit()
-        
+
         # Instantiate a server handle
         host_name = self._engine.execute_hook_method("project_startup_hook", "get_server_hostname")
         self._server = WireTapServerHandle("%s:IFFFS" % host_name)
         self._engine.log_debug("Connected to wiretap host '%s'..." % host_name)
-    
+
     def close(self):
         """
         Closes the wiretap connection
         """
         # Make sure to always uninitialize WireTap services in case of
-        # exception, otherwise wiretap server will refuse all the 
+        # exception, otherwise wiretap server will refuse all the
         # following connections.
         self._server = None
         WireTapClientUninit()
         self._engine.log_debug("Uninitialized wiretap...")
-        
+
     def prepare_and_load_project(self):
         """
         Load and prepare the project represented by the current context
-        
+
         :returns: arguments to pass to the Flame launch command line
         """
         user_name = self._engine.execute_hook_method("project_startup_hook", "get_user")
         project_name = self._engine.execute_hook_method("project_startup_hook", "get_project_name")
         workspace_name = self._engine.execute_hook_method("project_startup_hook", "get_workspace")
-        
+
         self._ensure_project_exists(project_name, user_name, workspace_name)
         self._ensure_user_exists(user_name)
-        
+
         if workspace_name is None:
             # use Flame's default workspace
             self._engine.log_debug("Using the Flame default workspace")
             app_args = "--start-project='%s' --start-user='%s' --create-workspace" % (project_name, user_name)
-            
+
         else:
             self._engine.log_debug("Using a custom workspace '%s'" % workspace_name)
             # an explicit workspace is used. Ensure it exists
             self._ensure_workspace_exists(project_name, workspace_name)
             # and pass it to the startup
-            app_args = "--start-project='%s' --start-user='%s' --create-workspace --start-workspace='%s'" % (project_name, 
-                                                                                                             user_name, 
+            app_args = "--start-project='%s' --start-user='%s' --create-workspace --start-workspace='%s'" % (project_name,
+                                                                                                             user_name,
                                                                                                              workspace_name)
-        
+
         return app_args
-    
-    
-    
+
     #########################################################################################################
     # internals
-        
+
     def _ensure_user_exists(self, user_name):
         """
         Ensures the given user exists
-        
+
         :param user_name: Name of the user to look for
         """
-        
+
         if not self._child_node_exists("/users", user_name, "USER"):
             # Create the new user
             users = WireTapNodeHandle(self._server, "/users")
-       
+
             user_node = WireTapNodeHandle()
             if not users.createNode(user_name, "USER", user_node):
                 raise WiretapError("Unable to create user %s: %s" % (user_name, users.lastError()))
- 
+
             self._engine.log_debug("User %s successfully created" % user_name)
 
     def _ensure_workspace_exists(self, project_name, workspace_name):
         """
         Ensures that the given workspace exists
-        
+
         :param project_name: Project to look in
-        :param workspace_name: Workspace name to look for        
+        :param workspace_name: Workspace name to look for
         """
-        
+
         if not self._child_node_exists("/projects/%s" % project_name, workspace_name, "WORKSPACE"):
             project = WireTapNodeHandle(self._server, "/projects/%s" % project_name)
-       
+
             workspace_node = WireTapNodeHandle()
             if not project.createNode(workspace_name, "WORKSPACE", workspace_node):
                 raise WiretapError("Unable to create workspace %s in "
                                    "project %s: %s" % (workspace_name, project_name, project.lastError()) )
- 
+
         self._engine.log_debug("Workspace %s successfully created" % workspace_name)
- 
+
     def _ensure_project_exists(self, project_name, user_name, workspace_name):
         """
         Ensures that the given project exists
-        
+
         :param project_name: Project name to look for
         :param user_name: User name to use when starting up
         :param workspace_name: Workspace to use when starting up - if none, then default ws will be used.
         """
         from sgtk.platform.qt import QtGui, QtCore
-        
+
         if not self._child_node_exists("/projects", project_name, "PROJECT"):
 
             # we need to create a new project!
 
             # first decide which volume to create the project on.
-            # get a list of volumes and pass it to a hook which will 
+            # get a list of volumes and pass it to a hook which will
             # return the volume to use
             volumes = self._get_volumes()
-            
+
             if len(volumes) == 0:
                 raise TankError("Cannot create new project! There are no volumes defined for this Flame!")
-            
+
             # call out to the hook to determine which volume to use
             volume_name = self._engine.execute_hook_method("project_startup_hook", "get_volume", volumes=volumes)
 
@@ -177,12 +175,12 @@ class WiretapHandler(object):
             if volume_name not in volumes:
                 raise TankError("Volume '%s' specified in hook does not exist in "
                                 "list of current volumes '%s'" % (volume_name, volumes))
-            
+
             host_name = self._engine.execute_hook_method("project_startup_hook", "get_server_hostname")
-            
+
             # get project settings from the toolkit hook
             project_settings = self._engine.execute_hook_method("project_startup_hook", "get_project_settings")
-            
+
             # now check if we should pop up a ui where the user can tweak the default prefs
             if self._engine.execute_hook_method("project_startup_hook", "use_project_settings_ui"):
                 # at this point we don't have a QT application running, because we are still
@@ -190,8 +188,8 @@ class WiretapHandler(object):
                 # in a helper method which also creates a QApplication.
 
                 (group_name, groups) = self._get_groups()
-                (return_code, widget) = start_qt_app_and_show_modal("Create Flame Project", 
-                                                                    self._engine, 
+                (return_code, widget) = start_qt_app_and_show_modal("Create Flame Project",
+                                                                    self._engine,
                                                                     ProjectCreateDialog,
                                                                     project_name,
                                                                     user_name,
@@ -203,21 +201,21 @@ class WiretapHandler(object):
                                                                     groups,
                                                                     project_settings
                                                                     )
-                
+
                 if return_code == QtGui.QDialog.Rejected:
                     # user pressed cancel
                     raise TankError("Flame project creation aborted. Will not launch Flame.")
-                
+
                 # read updated settings back from the UI and update our settings dict with these
-                for (k, v) in widget.get_settings().iteritems(): 
+                for (k, v) in widget.get_settings().iteritems():
                     project_settings[k] = v
-                    
+
                 volume_name = widget.get_volume_name()
                 group_name = widget.get_group_name()
-                
+
             else:
-                self._engine.log_debug("Project settings ui will be bypassed.")            
-            # create the project : Using the command line tool here instead of the python API because we need root privileges to set the group id. 
+                self._engine.log_debug("Project settings ui will be bypassed.")
+            # create the project : Using the command line tool here instead of the python API because we need root privileges to set the group id.
             import subprocess, os
             project_create_cmd = [
                 os.path.join(self._engine.wiretap_tools_root, "wiretap_create_node"),
@@ -231,7 +229,7 @@ class WiretapHandler(object):
                 project_create_cmd.append(group_name)
 
             subprocess.check_call(project_create_cmd)
- 
+
             # create project settings
 
             self._engine.log_debug("A new project '%s' will be created." % project_name)
@@ -244,12 +242,12 @@ class WiretapHandler(object):
             # NOTE! It seems the attribute order in the xml data may be significant
             # when the data is read into flame. Moving proxy parameters round in the past
             # has resulted in regressions, so ensure the xml structure is the intact
-            # when making modifications. 
+            # when making modifications.
 
             xml  = "<Project>"
-            
+
             xml += "<Description>%s</Description>"             % "Created by Shotgun Flame Integration %s" % self._engine.version
-            
+
             xml += self._append_setting_to_xml(project_settings, "SetupDir")
             xml += self._append_setting_to_xml(project_settings, "FrameWidth")
             xml += self._append_setting_to_xml(project_settings, "FrameHeight")
@@ -257,7 +255,7 @@ class WiretapHandler(object):
             xml += self._append_setting_to_xml(project_settings, "AspectRatio")
             xml += self._append_setting_to_xml(project_settings, "FrameRate")
             xml += self._append_setting_to_xml(project_settings, "ProxyEnable", stops_working_in="2016.1")
-            xml += self._append_setting_to_xml(project_settings, "FieldDominance")            
+            xml += self._append_setting_to_xml(project_settings, "FieldDominance")
             xml += self._append_setting_to_xml(project_settings, "VisualDepth", starts_working_in="2015.3", stops_working_in="2018.0")
 
             # proxy settings
@@ -266,12 +264,12 @@ class WiretapHandler(object):
             xml += self._append_setting_to_xml(project_settings, "ProxyMinFrameSize")
             xml += self._append_setting_to_xml(project_settings, "ProxyAbove8bits", stops_working_in="2016.1")
             xml += self._append_setting_to_xml(project_settings, "ProxyQuality")
-                        
+
             # new proxy parameters added in 2016.1
             xml += self._append_setting_to_xml(project_settings, "ProxyRegenState", starts_working_in="2016.1")
-            
+
             xml += "</Project>"
-    
+
             # force cast to string - values coming from qt are unicode...
             xml = str(xml)
 
@@ -279,19 +277,18 @@ class WiretapHandler(object):
             pretty_xml = minidom.parseString(xml).toprettyxml()
             self._engine.log_debug("The following xml will be emitted: %s" % pretty_xml)
 
-    
             # Set the project meta data
             project_node = WireTapNodeHandle(self._server, "/projects/" + project_name)
             if not project_node.setMetaData("XML", xml):
                 raise WiretapError("Error setting metadata for %s: %s" % (project_name, project_node.lastError()))
-            
+
             self._engine.log_debug( "Project successfully created.")
 
     def _append_setting_to_xml(self, project_settings, setting, starts_working_in=None, stops_working_in=None):
         """
         Generates xml for a parameter. May return an empty string if the xml
         cannot or should not be generated.
-        
+
         :param project_settings: Dictionary of parameters
         :param setting: Setting to generate xml for
         :param starts_working_in: Version of flame that supports this setting.
@@ -300,62 +297,60 @@ class WiretapHandler(object):
                                   ignore the parameter and return an empty string.
         :param stops_working_in: Version of Flame where this parameter stopped
                                  being supported. The reciprocal of starts_working_in.
-        
+
         :returns: Empty string or '<setting>value</setting>'
         """
         xml = ""
         if project_settings.get(setting):
-            
+
             if starts_working_in and self._engine.is_version_less_than(starts_working_in):
                 # our version of flame is too old
-                self._engine.log_warning("Ignoring '%s' directive since this is " 
+                self._engine.log_warning("Ignoring '%s' directive since this is "
                                          "not supported by this version of Flame" % setting)
-                
-                
+
             elif stops_working_in and not self._engine.is_version_less_than(stops_working_in):
                 # our version of flame is too new
-                self._engine.log_warning("Ignoring '%s' directive since this is " 
+                self._engine.log_warning("Ignoring '%s' directive since this is "
                                          "no longer supported by this version of Flame" % setting)
-                
+
             else:
                 xml = "<%s>%s</%s>" % (setting, project_settings.get(setting), setting)
         return xml
-    
 
     def _get_volumes(self):
         """
         Return a list of volumes available
-        
+
         :returns: List of volume names
         """
         root = WireTapNodeHandle(self._server, "/volumes")
         num_children = WireTapInt(0)
         if not root.getNumChildren(num_children):
             raise WiretapError("Unable to obtain number of volumes: %s" % root.lastError())
-        
+
         volumes = []
-        
+
         # iterate over children, look for the given node
         child_obj = WireTapNodeHandle()
         for child_idx in range(num_children):
-            
+
             # get the child
             if not root.getChild(child_idx, child_obj):
-                raise WiretapError("Unable to get child: %s" % parent.lastError())
-    
+                raise WiretapError("Unable to get child: %s" % root.lastError())
+
             node_name = WireTapStr()
-            
+
             if not child_obj.getDisplayName(node_name):
                 raise WiretapError("Unable to get child name: %s" % child_obj.lastError())
- 
+
             volumes.append(node_name.c_str())
-        
+
         return volumes
 
     def _get_groups(self):
         """
         Return the list of group available for the current user and the current group.
-        
+
         :returns: (default_group, groups)
         """
 
@@ -373,15 +368,15 @@ class WiretapHandler(object):
     def _child_node_exists(self, parent_path, child_name, child_type):
         """
         Helper method. Check if a wiretap node exists.
-        
+
         :param parent_path: Parent node to scan
         :param child_name: Name of child node to look for
         :param child_type: Type of child node to look for
         :returns: True if node exists, false otherwise.
-        """ 
+        """
         # get the parent
         parent = WireTapNodeHandle(self._server, parent_path)
-        
+
         # get number of children
         num_children = WireTapInt(0)
         if not parent.getNumChildren(num_children):
@@ -389,24 +384,24 @@ class WiretapHandler(object):
                                "children for node %s. Please check that your "
                                "wiretap service is running. "
                                "Error reported: %s" % (parent_path, parent.lastError()))
-                            
+
         # iterate over children, look for the given node
         child_obj = WireTapNodeHandle()
         for child_idx in range(num_children):
-            
+
             # get the child
             if not parent.getChild(child_idx, child_obj):
                 raise WiretapError("Unable to get child: %s" % parent.lastError())
-    
+
             node_name = WireTapStr()
             node_type = WireTapStr()
-            
+
             if not child_obj.getDisplayName(node_name):
                 raise WiretapError("Unable to get child name: %s" % child_obj.lastError())
             if not child_obj.getNodeTypeStr(node_type):
                 raise WiretapError("Unable to obtain child type: %s" % child_obj.lastError())
- 
+
             if node_name.c_str() == child_name and node_type.c_str() == child_type:
                 return True
-       
+
         return False


### PR DESCRIPTION
JIRA: SMOK-48328 SMOK-49004 SMOK-48654 SMOK-48548
SMOK-48328 - Use PyExporter in tk-flame
SMOK-49004 - Add way to disable server side transcoding in tk-flame
SMOK-48654 - Many Publisher Windows are showing as many Write nodes output on rendering.

- Support for Flame Python Export API (2019.1 +)

  Use the new Python API Exporter framework to reimplement transcoding in
  the engine. There is now two transcoding engine available, one use Flame's
  code and the other one using FFmpeg/read_frame.

  The one using Flame's code will be prefered over the one using FFmepg if
  available (starting with Flame 2019.1).

  Settings are available in the info.yml to chose the presets used for
  thumbnail, preview and local movie generation as well as toggling on/off
  the generation itself.

- Fixes for publisher workflows for Flame 2019.1 +

  There are additionnals hooks available in Flame 2019.1 that can be used
  to fix publishers problems. Mainly the multiple publisher windows showing
  up in Batch.

- Fix simple problems reported by Pylint (mainly whitespace stuff).