### PR TITLE
Fix import of Wiretap Python API from adsk site-packages

### DIFF
--- a/python/tk_flame/wiretap.py
+++ b/python/tk_flame/wiretap.py
@@ -41,7 +41,14 @@ class WiretapError(TankError):
 # note: this is one of those C style library wrappers
 # where each method internally is prefixed with
 # WireTap, hence the dropping of the namespace.
-from libwiretapPythonClientAPI import *
+try:
+  from adsk.libwiretapPythonClientAPI import *
+except ImportError:
+  # Older version of Flame distributed that in the
+  #/opt/Autodesk/<app>_<version>/python directory which required the current
+  # working directory to be that directory in order to work.
+  #
+  from libwiretapPythonClientAPI import *
 
 from .project_create_dialog import ProjectCreateDialog
 from .qt_task import start_qt_app_and_show_modal


### PR DESCRIPTION
JIRA: SMOK-49312

WireTap Python API primary location is now /opt/Autodesk/python/<version>/lib/python2.7/site-packages/adsk

There is still a symlink pointing to it in /opt/Autodesk/flame_<version>/python but it do not seem to work if the python executable started with /opt/Autodesk/flame_<version>/python as the current working directory.

Use the site package location first and fallback to the relative path afterward to prevent errors