### PR TITLE
Return thubmnail generation job ids

### DIFF
--- a/hooks/backburner_hooks.py
+++ b/hooks/backburner_hooks.py
@@ -165,8 +165,8 @@ class BackburnerHooks(HookBaseClass):
                 self.parent.log_warning("Movie process failed!\nError code: %s\nOutput:\n%s" % (return_code, stderr))
                 return return_code
 
-            if self.engine.get_setting("bypass_server_transcoding"):
-                self.engine.log_debug("Bypass Shotgun transcoding setting enabled.")
+            if self.parent.get_setting("bypass_server_transcoding"):
+                self.parent.log_debug("Bypass Shotgun transcoding setting enabled.")
                 field_name = "sg_uploaded_movie_mp4"
             else:
                 field_name = "sg_uploaded_movie"

--- a/info.yml
+++ b/info.yml
@@ -100,9 +100,10 @@ configuration:
     generate_local_movies:
         type: bool
         default_value: True
-        description: Generate an higher quality movies file that will not be uploaded to shotgun but
-                     can be used by client applications that do not want or cannot read original exported
-                     media from Flame.
+        description: Global switch to allow or not the generation an higher quality movies
+                     file that will not be uploaded to shotgun but can be used by client applications
+                     that do not want or cannot read original exported media from Flame.
+                     This is currently only used by tk-flame-export.
 
     local_movies_preset_path:
         type: str

--- a/python/tk_flame/local_movie_generator.py
+++ b/python/tk_flame/local_movie_generator.py
@@ -63,7 +63,7 @@ class LocalMovieGenerator(object):
         self.engine.create_local_backburner_job(
             job_name="%s - Updating Shotgun Path to movie" % display_name,
             description="Uploading Shotgun Path to movie to %s" % dst_path,
-            run_after_job_id=job_id,
+            dependencies=job_id,
             instance="backburner_hooks",
             method_name="update_path_to_movie",
             args={

--- a/python/tk_flame/thumbnail_generator.py
+++ b/python/tk_flame/thumbnail_generator.py
@@ -151,5 +151,6 @@ class ThumbnailGenerator(object):
         :param path: Path to the media for which thumbnail or/and preview need
             to be uploaded to Shotgun. If None is pass, all jobs will be
             finalized.
+        :return: Backburner job IDs created.
         """
         raise NotImplementedError


### PR DESCRIPTION
JIRA: SMOK-49295
Use PyExporter in tk-flame-review

Return the Backburner jobs ids created by the Thumbnail generator so
dependent backburner job can be scheduled. This is required to integrate
the Thumbnail generator in tk-flame-review since we want to be able to
delete the created movie file when the thumbnail generation job is finished.