### PR TITLE
Support creating transcoding job of unwritten quicktime file

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1242,7 +1242,7 @@ class FlameEngine(sgtk.platform.Engine):
 
         # Note. Flame exporter can be used in 2019.1 but there are issues
         #       with transcoding of Movie files that prevent wide use of it
-        #       before 2016.2.
+        #       with 2019.1.
         #
         return not self.is_version_less_than("2016.2")
 

--- a/engine.py
+++ b/engine.py
@@ -1244,7 +1244,7 @@ class FlameEngine(sgtk.platform.Engine):
         #       with transcoding of Movie files that prevent wide use of it
         #       with 2019.1.
         #
-        return not self.is_version_less_than("2016.2")
+        return not self.is_version_less_than("2019.2")
 
     @property
     def transcoder(self):

--- a/engine.py
+++ b/engine.py
@@ -141,7 +141,6 @@ class FlameEngine(sgtk.platform.Engine):
         # type we will need, we need to wait for the Flame API to be loaded
         # completely.
         #
-        self._flame_exporter_supported_check = None
         self._transcoder = None
         self._thumbnail_generator = None
         self._local_movie_generator = None
@@ -1241,18 +1240,11 @@ class FlameEngine(sgtk.platform.Engine):
         :return True if Flame exporter API is supported.
         """
 
-        if self._flame_exporter_supported_check is not None:
-            return self._flame_exporter_supported_check
-
-        try:
-            import flame
-            if "import_clips" in dir(flame) and "PyExporter" in dir(flame):
-                self._flame_exporter_supported_check = True
-            else:
-                self._flame_exporter_supported_check = False
-        except ImportError:
-            self._flame_exporter_supported_check = False
-        return self._flame_exporter_supported_check
+        # Note. Flame exporter can be used in 2019.1 but there are issues
+        #       with transcoding of Movie files that prevent wide use of it
+        #       before 2016.2.
+        #
+        return not self.is_version_less_than("2016.2")
 
     @property
     def transcoder(self):

--- a/flame_hooks/sg_export_hook.py
+++ b/flame_hooks/sg_export_hook.py
@@ -42,6 +42,7 @@ def preCustomExport(info, userData):
                  - destinationHost: Host name where the exported files will be written to.
                  - destinationPath: Export path root.
                  - presetPath: Path to the preset used for the export.
+                 - isBackground: Perform the export in background. (True if not defined)
                  - abort: Pass True back to Flame if you want to abort
                  - abortMessage: Abort message to feed back to client
                  

--- a/python/tk_flame/transcoder.py
+++ b/python/tk_flame/transcoder.py
@@ -155,6 +155,16 @@ class Transcoder(object):
             metadata["fieldDominance"] = 2
         metadata["colourSpace"] = asset_info.get("colourSpace", "Unknown")
 
+        extension = os.path.splitext(src_path)[1].lower()
+        handlers = {
+            ".mov": "Quicktime"
+        }
+        handler = handlers.get(extension, None)
+        if handler is not None:
+            metadata["handler"] = "<handler><name>%s</name></handler>" % handler
+        else:
+            metadata["handler"] = ""
+
         os.write(
             tmp_fd,
             """
@@ -164,6 +174,7 @@ class Transcoder(object):
                <trackType>video</trackType>
                <feeds currentVersion=\"v0\">
                 <feed type=\"feed\" vuid=\"v0\" uid=\"v0\">
+                 {handler}
                  <storageFormat type=\"format\">
                   <type>video</type>
                   <nbChannels type=\"uint\">{nbChannels}</nbChannels>


### PR DESCRIPTION
JIRA: SMOK-49295

Open Clip can open Quickime file with multiple handler.
When that happen, the file need to be there to know which one we want to use.

However, in the case of the transcoder, this Quicktime one is the one we
will want to use so remove the ambiguity.