### PR TITLE
Fix movie preview only have one frame

### DIFF
--- a/python/tk_flame/transcoder.py
+++ b/python/tk_flame/transcoder.py
@@ -156,10 +156,10 @@ class Transcoder(object):
         metadata["colourSpace"] = asset_info.get("colourSpace", "Unknown")
 
         try:
-            sourceIn = int(asset_info.get("sourceIn", 0))
-            sourceOut = int(asset_info.get("sourceOut", sourceIn + 1))
-            nbFrames = sourceOut - sourceIn
-            metadata["duration"] = "<duration>%d</duration>" % (nbFrames)
+            source_in = int(asset_info.get("sourceIn", 0))
+            source_out = int(asset_info.get("sourceOut", source_in + 1))
+            nb_frames = source_out - source_in
+            metadata["duration"] = "<duration>%d</duration>" % (nb_frames)
         except:
             metadata["duration"] = ""
 

--- a/python/tk_flame/transcoder.py
+++ b/python/tk_flame/transcoder.py
@@ -155,6 +155,16 @@ class Transcoder(object):
             metadata["fieldDominance"] = 2
         metadata["colourSpace"] = asset_info.get("colourSpace", "Unknown")
 
+        try:
+            sourceIn = int(asset_info.get("sourceIn", 0))
+            sourceOut = int(asset_info.get("sourceOut", sourceIn + 1))
+            nbFrames = sourceOut - sourceIn
+            metadata["duration"] = "<duration>%d</duration>" % (nbFrames)
+        except:
+            metadata["duration"] = ""
+
+        metadata["sampleRate"] = asset.info.get("fps")
+
         extension = os.path.splitext(src_path)[1].lower()
         handlers = {
             ".mov": "Quicktime"
@@ -187,8 +197,10 @@ class Transcoder(object):
                   <fieldDominance type=\"int\">{fieldDominance}</fieldDominance>
                   <colourSpace type=\"string\">{colourSpace}</colourSpace>
                  </storageFormat>
+                 <sampleRate>{sampleRate}</sampleRate>
                  <spans type=\"spans\">
                   <span type=\"span\">
+                   {duration}
                    <path encoding=\"pattern\">{path}</path>
                   </span>
                  </spans>

--- a/python/tk_flame/transcoder.py
+++ b/python/tk_flame/transcoder.py
@@ -163,7 +163,7 @@ class Transcoder(object):
         except:
             metadata["duration"] = ""
 
-        metadata["sampleRate"] = asset.info.get("fps")
+        metadata["sampleRate"] = asset_info.info.get("fps")
 
         extension = os.path.splitext(src_path)[1].lower()
         handlers = {

--- a/python/tk_flame/transcoder.py
+++ b/python/tk_flame/transcoder.py
@@ -163,7 +163,7 @@ class Transcoder(object):
         except:
             metadata["duration"] = ""
 
-        metadata["sampleRate"] = asset_info.info.get("fps")
+        metadata["sampleRate"] = asset_info.get("fps")
 
         extension = os.path.splitext(src_path)[1].lower()
         handlers = {


### PR DESCRIPTION
JIRA: SMOK-49295

We write an temporary Open Clip file pointing to the file that will be
exported by flame before so the preview job can be sent before the background
export job finishes.

However the file we were writting did not have a duration which implicitly
means that the nubmer of file is the number of frame (unless the media file
header can be read which is not the case when the export is still going).

This resulted in one frame movie file preview. The fix is to write the
duration in the Open Clip. I've added the fps at the same time to ensure proper
playback speed.

will be ignored, and an empty message aborts the commit. # # On branch
dev/braultj/movie-lenght # Your branch is up to date with 'origin/master'. # #
Changes to be committed: #	modified:   python/tk_flame/transcoder.py #