### PR TITLE
Fix export job dependencies

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1401,12 +1401,7 @@ class FlameEngine(sgtk.platform.Engine):
         # Set the backburner job dependencies
         if dependencies:
             if isinstance(dependencies, list):
-                if len(dependencies) > 1:
-                    if self.is_version_less_than("2019.1"):
-                        raise TankError("Multiple job dependencies not supported before 2019.1")
-                    backburner_args.append("-dependencies:%s" % ",".join(dependencies))
-                else:
-                    backburner_args.append("-dependencies:%s" % dependencies[0])
+                backburner_args.append("-dependencies:%s" % ",".join(dependencies)) 
             else:
                 backburner_args.append("-dependencies:%s" % dependencies)
 

--- a/hooks/tk-multi-publish2/publish_file.py
+++ b/hooks/tk-multi-publish2/publish_file.py
@@ -176,10 +176,6 @@ class CreatePublishPlugin(HookBaseClass):
 
         # Create a Thumbnail in Background for compatible Flame related PublishedFile
         if item.display_type in ["Flame OpenClip", "Flame Render", "Flame Batch OpenClip"]:
-            # Extract the Backburner dependencies
-            job_ids = item.properties.get("backgroundJobId")
-            job_ids_str = ",".join(job_ids) if job_ids else None
-
             # For file sequences, the hooks we want the path as provided by flame.
             path = item.properties.get("file_path", path)
 

--- a/python/tk_flame/thumbnail_generator_ffmpeg.py
+++ b/python/tk_flame/thumbnail_generator_ffmpeg.py
@@ -51,7 +51,7 @@ class ThumbnailGeneratorFFmpeg(ThumbnailGenerator):
         job_id = self.engine.create_local_backburner_job(
             job_name,
             job_description,
-            ",".join(dependencies) if dependencies else None,
+            dependencies,
             "backburner_hooks",
             "attach_mov_preview",
             {
@@ -91,7 +91,7 @@ class ThumbnailGeneratorFFmpeg(ThumbnailGenerator):
         job_id = self.engine.create_local_backburner_job(
             job_name,
             job_description,
-            ",".join(dependencies) if dependencies else None,
+            dependencies,
             "backburner_hooks",
             "attach_jpg_preview",
             {


### PR DESCRIPTION
JIRA: SMOK-48751
Use PyExporter in tk-flame-export

The job list was not built correctly for a single dependency causing the
string of the job ID to be split into a list of one digit job id.

Also, remove limitation that 2019.1 could only send one job since cmdjob
supported multiple job for a long time (more than 10 years).