### PR TITLE
Re-enable "Create Batch Group" otion in loader

### DIFF
--- a/hooks/tk-multi-loader2/flame_loader_actions.py
+++ b/hooks/tk-multi-loader2/flame_loader_actions.py
@@ -28,7 +28,7 @@ else:
 
 HookBaseClass = sgtk.get_hook_baseclass()
 
-##############################################################################################################
+####################################################################################################
 # Constants to be used with Flame
 
 SETUP_ACTION = "load_setup"
@@ -42,7 +42,7 @@ class FlameLoaderActionError(Exception):
 
 
 class FlameLoaderActions(HookBaseClass):
-    ##############################################################################################################
+    ################################################################################################
     # public interface - to be overridden by deriving classes
     def generate_actions(self, sg_publish_data, actions, ui_area):
         """
@@ -93,30 +93,38 @@ class FlameLoaderActions(HookBaseClass):
             return action_instances
 
         if SETUP_ACTION in actions and hasattr(flame.batch, "append_setup"):
-            action_instances.append({"name": SETUP_ACTION,
-                                     "params": None,
-                                     "caption": "Load and Append Batch Setup",
-                                     "description": "Load and append a batch setup file to the current Batch Group."})
+            action_instances.append({
+                "name": SETUP_ACTION,
+                "params": None,
+                "caption": "Load and Append Batch Setup",
+                "description": "Load and append a batch setup file to the current Batch Group."
+            })
 
         if CLIP_ACTION in actions and hasattr(flame.batch, "import_clip"):
-            action_instances.append({"name": CLIP_ACTION,
-                                     "params": None,
-                                     "caption": "Import Clip",
-                                     "description": "Import a clip to the current Batch Group."})
+            action_instances.append({
+                "name": CLIP_ACTION,
+                "params": None,
+                "caption": "Import Clip",
+                "description": "Import a clip to the current Batch Group."
+            })
 
         if SHOT_CREATE_ACTION in actions and hasattr(flame.batch, "create_batch_group"):
-            action_instances.append({"name": SHOT_CREATE_ACTION,
-                                     "params": None,
-                                     "caption": "Create Batch Group",
-                                     "description": "Create a Batch setup inside a new Batch Group."})
+            action_instances.append({
+                "name": SHOT_CREATE_ACTION,
+                "params": None,
+                "caption": "Create Batch Group",
+                "description": "Create a Batch setup inside a new Batch Group."
+            })
 
         if SHOT_LOAD_ACTION in actions and hasattr(flame.batch, "load_setup"):
             batch_paths = self._get_batch_path_from_sg_publish_data(sg_publish_data)
             if batch_paths is not None:
-                action_instances.append({"name": SHOT_LOAD_ACTION,
-                                         "params": None,
-                                         "caption": "Load in new Batch Group",
-                                         "description": "Load a Batch setup file inside a new Batch Group."})
+                action_instances.append({
+                    "name": SHOT_LOAD_ACTION,
+                    "params": None,
+                    "caption": "Load in new Batch Group",
+                    "description": "Load a Batch setup file inside a new Batch Group."
+                })
 
         return action_instances
 
@@ -182,7 +190,8 @@ class FlameLoaderActions(HookBaseClass):
             else:
                 raise FlameLoaderActionError("Unknown action name: '{}'".format(name))
         except FlameLoaderActionError, error:
-            # A FlameActionError reaching here means that something major have stopped the current action
+            # A FlameActionError reaching here means that something major have
+            # stopped the current action
             QtGui.QMessageBox.critical(
                 None,
                 "Error",
@@ -190,7 +199,7 @@ class FlameLoaderActions(HookBaseClass):
             )
             app.log_error(error)
 
-    ##############################################################################################################
+    ################################################################################################
     # methods called by the menu options in the loader
 
     def _import_batch_file(self, sg_publish_data):
@@ -219,7 +228,8 @@ class FlameLoaderActions(HookBaseClass):
         """
         Imports a clip into Flame.
 
-        This function import the clip into self.import_location (Default: Schematic Reel 1) in the current Batch Group.
+        This function import the clip into self.import_location (Default: Schematic Reel 1)
+        in the current Batch Group.
 
         :param dict sg_publish_data: Shotgun data dictionary with all the standard publish fields.
         """
@@ -235,7 +245,8 @@ class FlameLoaderActions(HookBaseClass):
             if not flame.batch.import_clip(clip_path, self.import_location):
                 raise FlameLoaderActionError("Unable to import '%s'" % clip_path)
 
-        # The clip name doesn't directly exists, but it might contain a pattern that we need to resolve.
+        # The clip name doesn't directly exists, but it might
+        # contain a pattern that we need to resolve.
         elif clip_path and '%' in clip_path:
             new_path = self._handle_frame_range(clip_path)["path"]
 
@@ -256,11 +267,13 @@ class FlameLoaderActions(HookBaseClass):
         """
         Add a batch group into Flame.
 
-        If build_new is True, it loads last version of every clip present in the Shot, otherwise it create the batch
-        group using the latest version of the batch file present in the Shot ( Do nothing if no batch file is present).
+        If build_new is True, it loads last version of every clip present in the Shot, otherwise it
+        create the batch group using the latest version of the batch file present in the Shot
+        (Do nothing if no batch file is present).
 
         :param dict sg_publish_data: Shotgun data dictionary with all the standard publish fields.
-        :param bool build_new: Hint about if we should build a new batch group from the clip or use the latest batch file
+        :param bool build_new: Hint about if we should build a new batch group from the clip or
+                               use the latest batch file
         """
 
         app = self.parent
@@ -281,7 +294,10 @@ class FlameLoaderActions(HookBaseClass):
             app.log_debug("Found Batch setup path: %s" % batch_path)
             # We found a batch file so let's import it
             if batch_path and self._exists(batch_path):
-                app.log_debug("Creating the '%s' batch group using '%s'" % (sg_publish_data['code'], batch_path))
+                app.log_debug(
+                    "Creating the '%s' batch group using '%s'" % (
+                        sg_publish_data['code'], batch_path
+                    ))
                 flame.batch.create_batch_group(sg_publish_data["code"])
                 if not flame.batch.load_setup(batch_path):
                     raise FlameLoaderActionError("Unable to load the Batch Setup")
@@ -290,7 +306,7 @@ class FlameLoaderActions(HookBaseClass):
             else:
                 raise FlameLoaderActionError("No setup to load")
 
-    ##############################################################################################################
+    ################################################################################################
     # interface to the action hook configuration
 
     @property
@@ -307,7 +323,8 @@ class FlameLoaderActions(HookBaseClass):
     @property
     def supported_batch_types(self):
         """
-        Query the action_mappings entry to get every Published Type that's considered as a Batch file
+        Query the action_mappings entry to get every Published Type that's considered as
+        a Batch file
 
         :return: List of Published Type
         :rtype: [str]
@@ -578,7 +595,7 @@ class FlameLoaderActions(HookBaseClass):
             media_root, media_path, media_ext = self._build_path_from_template(self.media_path_template, fields)
             write_file_info["media_path"] = media_root
             write_file_info["media_path_pattern"] = media_path
-            while media_ext[0] == '.':
+            while media_ext[0] == ".":
                 media_ext = media_ext[1:]
             write_file_info["file_type"] = file_format.get(media_ext)
 
@@ -690,7 +707,7 @@ class FlameLoaderActions(HookBaseClass):
             try:
                 if path and self._exists(path):
                     published_files.append({"path": path, "info": file_info})
-                elif '%' in path:
+                elif "%" in path:
                     path_info = self._handle_frame_range(path)
 
                     published_files.append(

--- a/info.yml
+++ b/info.yml
@@ -124,6 +124,14 @@ configuration:
         default_value: False
 
 
+    media_path_root:
+        description: Default root directory of media for versions created by batch setup created
+                     by the loader. Can be overriden by the environment variable SHOTGUN_FLAME_MEDIA_PATH_ROOT.
+                     If no value is defined, rendering write file nodes will fails.
+        type: str
+        default_value: ""
+
+
     use_builtin_plugin:
         type: bool
         description: Whether to prepare the launch of Flame to make use of its builtin Toolkit


### PR DESCRIPTION
JIRA: SMOK-49516
Do not create write file node to /var/tmp when creating batch from shotgun

Do not create write file node to /var/tmp when creating batch by default.

Setting the default to an empty string will cause an error which is what we
want.

Add Settings to configure the default value that can be used instead of an
env var.

Fix template parsing done for create_batch not working anymore

We need to take into accoutn the {flame.frame} token that was added after this
feature was disabled.

Fix the extension parsing not mapping correctly to the file type if a . was
present.

Also, added more supported types in the batch write file node.