### PR TITLE
Support more asset types in publisher [2]

### DIFF
--- a/hooks/tk-multi-publish2/create_cut_item.py
+++ b/hooks/tk-multi-publish2/create_cut_item.py
@@ -145,7 +145,11 @@ class CreateCutPlugin(HookBaseClass):
         # Make sure that we have the Sequence in our context dict
         if "Sequence" not in item.properties["context"]:
             sequence_fields = ["cuts", "shots", "code"]
-            sequence = self.sg.find_one("Sequence", [["shots", "is", item.context.entity]], sequence_fields)
+            sequence = self.sg.find_one(
+                "Sequence",
+                [["shots", "is", item.context.entity]],
+                sequence_fields
+            )
             self.cache_entities(item.parent, [sequence])
 
             if sequence \
@@ -310,7 +314,7 @@ class CreateCutPlugin(HookBaseClass):
             "shot": item.properties.get("Shot"),
             "code": asset_info["assetName"],
             "version": item.properties.get("Version"),
-            "cut_order": asset_info["segmentIndex"]
+            "cut_order": asset_info.get("segmentIndex", 0)
         }
 
         cutitem_data["cut_item_duration"] = cutitem_data["cut_item_out"] - cutitem_data["cut_item_in"] + 1
@@ -334,7 +338,8 @@ class CreateCutPlugin(HookBaseClass):
 
         return cutitem_data
 
-    def _frames_to_timecode(self, total_frames, frame_rate, drop):
+    @staticmethod
+    def _frames_to_timecode(total_frames, frame_rate, drop):
         """
         Helper method that converts frames to SMPTE timecode.
 
@@ -431,7 +436,8 @@ class CreateCutPlugin(HookBaseClass):
         frames = int(total_frames % fps_int)
         return "%02d:%02d:%02d%s%02d" % (hours, minutes, seconds, smpte_token, frames)
 
-    def cache_entities(self, parent_item, entities):
+    @staticmethod
+    def cache_entities(parent_item, entities):
         """
         Cache the entity list on the item properties to avoid redundant database query.
 

--- a/hooks/tk-multi-publish2/create_cut_item.py
+++ b/hooks/tk-multi-publish2/create_cut_item.py
@@ -224,7 +224,7 @@ class CreateCutPlugin(HookBaseClass):
         targets = []
 
         # If this CutItem is the first element of the cut, update the thumbnail of the Cut
-        if asset_info["segmentIndex"] == 1:
+        if asset_info.get("segmentIndex", 1) == 1:
             targets.append(cut)
 
         # Create the CutItem
@@ -314,7 +314,7 @@ class CreateCutPlugin(HookBaseClass):
             "shot": item.properties.get("Shot"),
             "code": asset_info["assetName"],
             "version": item.properties.get("Version"),
-            "cut_order": asset_info.get("segmentIndex", 0)
+            "cut_order": asset_info.get("segmentIndex", 1)
         }
 
         cutitem_data["cut_item_duration"] = cutitem_data["cut_item_out"] - cutitem_data["cut_item_in"] + 1

--- a/hooks/tk-multi-publish2/update_shot.py
+++ b/hooks/tk-multi-publish2/update_shot.py
@@ -167,7 +167,7 @@ class UpdateShotPlugin(HookBaseClass):
         target = [item.context.entity]
 
         # If this is the first Shot of the Sequence, we update the Sequence thumbnail
-        if asset_info["segmentIndex"] == 1:
+        if asset_info.get("segmentIndex", 1) == 1:
             sequence = item.properties["context"]["Sequence"]
             target.append(sequence)
 
@@ -220,7 +220,7 @@ class UpdateShotPlugin(HookBaseClass):
             "description": item.description,
             "sg_cut_in": asset_info["recordIn"],
             "sg_cut_out": asset_info["recordOut"] - 1,
-            "sg_cut_order": asset_info["segmentIndex"],
+            "sg_cut_order": asset_info.get("segmentIndex", 1)
         }
 
         shot_data["sg_head_in"] = shot_data["sg_cut_in"] - asset_info["handleIn"]


### PR DESCRIPTION
JIRA: SMOK-51359
shot info is missing in Shotgun when published if "Create Open Clip" is disabled

Follow-up to previous branch.

The segment index of a single source will not be defined.
Return 0 for the cut order if this is the case.