### PR TITLE
Change `backburner_job_completion` setting default to "delete:1"

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -72,7 +72,7 @@ configuration:
 
     backburner_job_completion:
         type: str
-        default_value: "delete"
+        default_value: "delete:1"
         description: Action to be done on Backburner job completion.
                      Possible values are default, leaveInQueue, delete[:days], archive[:days].
                      Default will use the manager or application default for the action.


### PR DESCRIPTION
The `backburner_job_completion` setting should default to something
other than "delete". It is possible for the "Create Preview" job to
complete and delete itself before the "Upload Preview" job gets created
by tk-flame. Backburner will fail because the job dependency no longer
exists. Eliminate this race condition.