### PR TITLE
Fix sending backburner job on fully qualified host name

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1542,7 +1542,7 @@ class FlameEngine(sgtk.platform.Engine):
             "/var/tmp",
             "/usr/tmp"
         ]
-        localhost = os.uname()[1]
+        localhost = os.uname()[1].split(".")[0]
         if not bb_server_group and not bb_servers:
             # No servers/groups sepecified and local path.
             # Force the job to run on local server.


### PR DESCRIPTION
JIRA: SMOK-52621

On MacOS, os.uname() seem to return fully qualified host name for localhost.
Backburner will only use the first part as the name of the server.