### PR TITLE
Add an env var to set the Backburner Shared tmp

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1292,8 +1292,8 @@ class FlameEngine(sgtk.platform.Engine):
 
         :returns: path
         """
-        path = os.environ.get("SHOTGUN_FLAME_BACKBURNER_SHARED_TMP", self.get_setting("backburner_shared_tmp")
-
+        path = os.environ.get("SHOTGUN_FLAME_BACKBURNER_SHARED_TMP", self.get_setting("backburner_shared_tmp"))
+                          
         if not path:
             path = tempfile.gettempdir()
 

--- a/engine.py
+++ b/engine.py
@@ -1292,9 +1292,11 @@ class FlameEngine(sgtk.platform.Engine):
 
         :returns: path
         """
-        path = self.get_setting("backburner_shared_tmp")
+        path = os.environ.get("SHOTGUN_FLAME_BACKBURNER_SHARED_TMP", self.get_setting("backburner_shared_tmp"))
+        
         if not path:
             path = tempfile.gettempdir()
+        
         return path
 
 

--- a/engine.py
+++ b/engine.py
@@ -1292,11 +1292,11 @@ class FlameEngine(sgtk.platform.Engine):
 
         :returns: path
         """
-        path = os.environ.get("SHOTGUN_FLAME_BACKBURNER_SHARED_TMP", self.get_setting("backburner_shared_tmp"))
-        
+        path = os.environ.get("SHOTGUN_FLAME_BACKBURNER_SHARED_TMP", self.get_setting("backburner_shared_tmp")
+
         if not path:
             path = tempfile.gettempdir()
-        
+
         return path
 
 


### PR DESCRIPTION
This commit allows users to set the Backburner Shared folder without having to override a config.

This is useful for those using the Shotgun plugin without any configurations.