### PR TITLE
Use ShotgunCmdjob to push thumbnail to the cloud instead of cmdjob

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -77,6 +77,13 @@ configuration:
                      Possible values are default, leaveInQueue, delete[:days], archive[:days].
                      Default will use the manager or application default for the action.
 
+    backburner_cmd_job_type:
+        type: str
+        default_value: "ShotgunCmdjob"
+        description: The type of command line job to send to Backburner.
+                     This is defined by the name of the Command Line Adapter binary in
+                     Backburner Adapters folders.
+                     Not all versions of Backburner support this feature.
 
 
     generate_thumbnails:


### PR DESCRIPTION
JIRA: FLME-56959
Add Shotgun command line adapters

Newer installation of backburner support pluginName to be specified when sending
backburner command job. This is done by creating copy of the UserCmdjobAdapter
witht the a different name.

Flame thus install ShotgunCmdjob adapters on server 0, 2 & 3 and allow parallelization of the upload of the thumbnails without
having an impact on other command jobs.