### PR TITLE
Use ShotgunCmdjob to push thumbnail to the cloud instead of cmdjob

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -79,7 +79,7 @@ configuration:
 
     backburner_cmd_job_type:
         type: str
-        default_value: "UserCmdjobAdapter"
+        default_value: "ShotgunCmdjob"
         description: The type of command line job to send to Backburner.
                      This is defined by the name of the Command Line Adapter binary in
                      Backburner Adapters folders.


### PR DESCRIPTION
JIRA: FLME-56959
Add Shotgun command line adapters

Newer installation of backburner support pluginName to be specified when sending
backburner command job. This is done by creating copy of the UserCmdjobAdapter
with the a different name.

Flame thus install ShotgunCmdjob adapters on server 0, 2 & 3 and allow parallelization of the upload of the thumbnails without
having an impact on other command jobs.