### PR TITLE
Use socket.gethostname() to get the host name

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -23,6 +23,7 @@ import logging
 import logging.handlers
 import pprint
 import traceback
+import socket
 import subprocess
 import tempfile
 
@@ -1612,7 +1613,7 @@ class FlameEngine(sgtk.platform.Engine):
             "/var/tmp",
             "/usr/tmp",
         ]
-        localhost = os.uname()[1].split(".")[0]
+        localhost = socket.gethostname()
         if not bb_server_group and not bb_servers:
             # No servers/groups sepecified and local path.
             # Force the job to run on local server.


### PR DESCRIPTION
JIRA: FLME-58273

socket.gethostname() seem to return the same value as Backburner is expecting
in respect to FQDN hostname or not.