### PR TITLE
Improve support for machine having FQDN in host name

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1615,7 +1615,7 @@ class FlameEngine(sgtk.platform.Engine):
 
         if bb_servers:
             sanitized_bb_server_list = ""
-            for bb_server in bb_servers:
+            for bb_server in bb_servers.split(","):
                 sanitized_bb_server_list += self.get_backburner_server_name(bb_server)
             backburner_args.append('-servers:"%s"' % sanitized_bb_server_list)
 

--- a/engine.py
+++ b/engine.py
@@ -1511,10 +1511,15 @@ class FlameEngine(sgtk.platform.Engine):
     def get_backburner_server_name(hostname):
         # Only keep the domain if the domain is .local on mac
         #
-        server_name, server_domain = hostname.split(".")[0:2]
-        if sgtk.util.is_macos() and server_domain == "local":
-            server_name += ".local"
-        return server_name
+        splited_hostname = hostname.split(".")
+
+        if (
+            sgtk.util.is_macos()
+            and len(splited_hostname) == 2
+            and splited_hostname[1] == "local"
+        ):
+            return splited_hostname[0] + ".local"
+        return splited_hostname[0]
 
     def create_local_backburner_job(
         self,

--- a/engine.py
+++ b/engine.py
@@ -1640,15 +1640,22 @@ class FlameEngine(sgtk.platform.Engine):
         else:
             # Possible remote server but local only path.
             # Fail the job creation with an explicit message.
-            if temp_dir_is_local and (
-                bb_server_group or not bb_servers.startswith(local_server)
-            ):
-                raise TankError(
-                    "backburner_shared_tmp points to a local path (%s) and jobs can be ran "
-                    "on multiple Backburner servers. Change backburner_shared_tmp, "
-                    "backburner_server_group and/or backburner_servers settings in "
-                    "the configuration files." % temp_dir
-                )
+            if temp_dir_is_local:
+                all_local_servers = not bb_server_group
+                if all_local_servers:
+                    for bb_server in bb_servers.split(","):
+                        all_local_servers = bb_servers.startswith(local_server)
+                        if not all_local_servers:
+                            break
+                if not all_local_servers:
+                    raise TankError(
+                        "backburner_shared_tmp points to a local path (%s) and jobs can be ran "
+                        "on multiple Backburner servers. Change backburner_shared_tmp, "
+                        "backburner_server_group and/or backburner_servers settings in "
+                        "the configuration files or define SHOTGUN_FLAME_BACKBURNER_SHARED_TMP "
+                        "environment variable to point to a path valid on all Backburenr servers."
+                        % temp_dir
+                    )
 
         # Set the backburner job dependencies
         if dependencies:

--- a/engine.py
+++ b/engine.py
@@ -1611,7 +1611,7 @@ class FlameEngine(sgtk.platform.Engine):
         if bb_servers:
             sanitized_bb_server_list = ""
             for bb_server in bb_servers:
-                sanitized_bb_server_list += get_backburner_server_name(bb_server)
+                sanitized_bb_server_list += self.get_backburner_server_name(bb_server)
             backburner_args.append('-servers:"%s"' % sanitized_bb_server_list)
 
         # Check where the temporary data has/will be written. If the job is
@@ -1630,7 +1630,7 @@ class FlameEngine(sgtk.platform.Engine):
             if temp_dir_is_local:
                 break
 
-        local_server = get_backburner_server_name(socket.gethostname())
+        local_server = self.get_backburner_server_name(socket.gethostname())
 
         if not bb_server_group and not bb_servers:
             # No servers/groups sepecified and local path.


### PR DESCRIPTION
JIRA: FLME-58273

Use socket.gethostname() since it will return the hostname with .local on mac.
Keep the .local for the machien name since this is what backburner expect.
Strip the rest of the hostname.

Improve code that lookup for local path by only checking if the path starts with
temporary folder instead of contain.

Simiarly, check if the server starts with the localhost host name to support
server name with -# suffix.