### PR TITLE
Avoid refreshing credentials if not expired

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1723,7 +1723,8 @@ class FlameEngine(sgtk.platform.Engine):
 
         try:
             # Make sure that the session is not expired
-            sgtk.get_authenticated_user().refresh_credentials()
+            if sgtk.get_authenticated_user().are_credentials_expired():
+                sgtk.get_authenticated_user().refresh_credentials()
         except sgtk.authentication.AuthenticationCancelled:
             self.log_debug("User cancelled auth. No Backburner job will be created.")
         else:


### PR DESCRIPTION
JIRA: FLME-58463
ShotGrid: tk-flame reconnect to ShotGrid server each time a command line is sent

We refresh credentials before sending command line jobs since command line jobs
will be executed in a context where that will be impossible to show the UI
to validate the user crendentials.

This however can be quite long since it communicate with the ShotGrid server.
Only do it if credentials are expired.