### PR TITLE
Use Flame's python API execute_command() to start subprocesses 

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1876,10 +1876,6 @@ class FlameEngine(sgtk.platform.Engine):
                 if env_vars:
                     command = "/usr/bin/env " + " ".join(env_vars) + " " + command
 
-                print(command)
-                import pdb
-                pdb.set_trace()
-
                 return flame.execute_command(
                     command=command,
                     blocking=True,

--- a/engine.py
+++ b/engine.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Shotgun Software Inc.
+# Copyright (c) 2021 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY
 #
@@ -1416,8 +1416,9 @@ class FlameEngine(sgtk.platform.Engine):
             return self._cmdjob_supports_plugin_name
 
         backburner_job_cmd = os.path.join(self._install_root, "backburner", "cmdjob")
-        _, backburner_job_cmd_usage, _ = self.execute_command([backburner_job_cmd])
-
+        _, backburner_job_cmd_usage, _ = self.execute_hook_method(
+            "execute_command_hooks", "execute_command", command=[backburner_job_cmd]
+        )
         self._cmdjob_supports_plugin_name = False
         for line in backburner_job_cmd_usage.split("\n"):
             if "-pluginName:" in line:
@@ -1589,8 +1590,10 @@ class FlameEngine(sgtk.platform.Engine):
                 backburner_server_cmd = os.path.join(
                     self._install_root, "backburner", "backburnerServer"
                 )
-                _, bb_manager, _ = self.execute_command(
-                    [backburner_server_cmd, "-q", "MANAGER"]
+                _, bb_manager, _ = self.execute_hook_method(
+                    "execute_command_hooks",
+                    "execute_command",
+                    command=[backburner_server_cmd, "-q", "MANAGER"],
                 )
                 bb_manager = bb_manager.strip("\n")
 
@@ -1729,7 +1732,12 @@ class FlameEngine(sgtk.platform.Engine):
             self.log_debug("Method: %s with args %s" % (method_name, args))
 
             # kick it off
-            return_code, stdout, stderr = self.execute_command([full_cmd], shell=True)
+            return_code, stdout, stderr = self.execute_hook_method(
+                "execute_command_hooks",
+                "execute_command",
+                command=[full_cmd],
+                shell=True,
+            )
             self.log_debug(stdout)
 
             job_id_regex = re.compile(r"(?<=Successfully submitted job )(\d+)")
@@ -1835,68 +1843,6 @@ class FlameEngine(sgtk.platform.Engine):
         :returns: Absolute path as a string
         """
         return self.__get_wiretap_central_binary("read_frame")
-
-    @staticmethod
-    def execute_command(command, shell=False):
-        try:
-            import flame
-
-            # Newer version of Flame provides a way to run a command line
-            # through the Autodesk Flame Multi-Purpose Daemon. This way of
-            # starting new processes is better since any native python
-            # subprocess command (os.system, subprocess, Popen, etc) will call
-            # fork() which will duplicate the process resources before calling
-            # exec(). This can be costly especially for a process like Flame.
-            #
-            # Note: Environment variables will not be forwarded to the command
-            # executed automatically, use /usr/bin/env if we have any env var
-            # of interest.
-            #
-            if "execute_command" in dir(flame):
-
-                def is_env_var_forwaded(env_var):
-                    forwarded_env_vars = ["SSL_CERT_FILE", "SSL_CERT_DIR"]
-                    if env_var in forwarded_env_vars:
-                        return True
-
-                    forwarded_env_var_prefixes = ["SHOTGUN_", "TK_", "SGTK_", "TANK_"]
-                    for prefix in forwarded_env_var_prefixes:
-                        if env_var.startswith(prefix):
-                            return True
-
-                    return False
-
-                env_vars = []
-                for env_var in os.environ.items():
-                    if is_env_var_forwaded(env_var[0]):
-                        env_vars.append("=".join(env_var))
-
-                if isinstance(command, list):
-                    command = " ".join(command)
-                if env_vars:
-                    command = "/usr/bin/env " + " ".join(env_vars) + " " + command
-
-                return flame.execute_command(
-                    command=command,
-                    blocking=True,
-                    shell=shell,
-                    capture_stdout=True,
-                    capture_stderr=True,
-                )
-        except ImportError:
-            pass
-        import subprocess
-
-        process = subprocess.Popen(
-            command if isinstance(command, list) else command.split(" "),
-            stdout=subprocess.PIPE,
-            shell=shell,
-        )
-        stdout, stderr = process.communicate()
-        stdout = stdout.decode("utf-8") if stdout else None
-        stderr = stderr.decode("utf-8") if stderr else None
-        rc = process.returncode
-        return rc, stdout, stderr
 
 
 def sgtk_exception_trap(ex_cls, ex, tb):

--- a/hooks/backburner_hooks.py
+++ b/hooks/backburner_hooks.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 Shotgun Software Inc.
+# Copyright (c) 2021 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY
 #
@@ -110,8 +110,11 @@ class BackburnerHooks(HookBaseClass):
         try:
             full_cmd = "%s > %s" % (input_cmd, jpg_path)
 
-            return_code, _, stderr = sgtk.platform.current_engine().execute_command(
-                [full_cmd], shell=True
+            return_code, _, stderr = sgtk.platform.current_engine().execute_hook_method(
+                "execute_command_hooks",
+                "execute_command",
+                command=[full_cmd],
+                shell=True,
             )
 
             if return_code:
@@ -169,8 +172,11 @@ class BackburnerHooks(HookBaseClass):
                 mov_path,
             )
 
-            return_code, _, stderr = sgtk.platform.current_engine().execute_command(
-                [full_cmd], shell=True
+            return_code, _, stderr = sgtk.platform.current_engine().execute_hook_method(
+                "execute_command_hooks",
+                "execute_command",
+                command=[full_cmd],
+                shell=True,
             )
 
             if return_code:

--- a/hooks/backburner_hooks.py
+++ b/hooks/backburner_hooks.py
@@ -17,7 +17,6 @@ from sgtk import TankError
 from functools import partial
 from tempfile import mkstemp
 import os
-import subprocess
 
 HookBaseClass = sgtk.get_hook_baseclass()
 
@@ -111,9 +110,9 @@ class BackburnerHooks(HookBaseClass):
         try:
             full_cmd = "%s > %s" % (input_cmd, jpg_path)
 
-            jpg_job = subprocess.Popen([full_cmd], stdout=subprocess.PIPE, shell=True)
-            _, stderr = jpg_job.communicate()
-            return_code = jpg_job.returncode
+            return_code, _, stderr = sgtk.platform.current_engine().execute_command(
+                [full_cmd], shell=True
+            )
 
             if return_code:
                 self.parent.log_warning(
@@ -170,9 +169,9 @@ class BackburnerHooks(HookBaseClass):
                 mov_path,
             )
 
-            mov_job = subprocess.Popen([full_cmd], stdout=subprocess.PIPE, shell=True)
-            _, stderr = mov_job.communicate()
-            return_code = mov_job.returncode
+            return_code, _, stderr = sgtk.platform.current_engine().execute_command(
+                [full_cmd], shell=True
+            )
 
             if return_code:
                 self.parent.log_warning(

--- a/hooks/execute_command.py
+++ b/hooks/execute_command.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2021 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Hook that handles excutement command line from within the Flame process.
+"""
+
+from __future__ import absolute_import
+import sgtk
+
+import os
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class ExecuteCommandHooks(HookBaseClass):
+    def use_flame_execute_command(self):
+        """
+        Newer version of Flame provides a way to run a command line
+        through the Autodesk Flame Multi-Purpose Daemon. This way of
+        starting new processes is better since any native python
+        subprocess command (os.system, subprocess, Popen, etc) will call
+        fork() which will duplicate the process resources before calling
+        exec(). This can be costly especially for a process like Flame.
+
+        Note: Environment variables will not be forwarded to the command
+        executed automatically, use /usr/bin/env if we have any env var
+        of interest defined by is_env_var_forwaded(). Because of that it is
+        not enabled by default since it could break legacy workflows that
+        would be dependent of env vars.
+        """
+        return os.environ.get("SHOTGUN_FLAME_USE_EXECUTE_COMMAND", False)
+
+    def is_env_var_forwaded(self, env_var):
+        """
+        Query if an env var should be forward to a new command line process.
+
+        :param env_var: Environement variable name
+        """
+        forwarded_env_vars = ["SSL_CERT_FILE", "SSL_CERT_DIR"]
+        if env_var in forwarded_env_vars:
+            return True
+
+        forwarded_env_var_prefixes = ["SHOTGUN_", "TK_", "SGTK_", "TANK_"]
+        for prefix in forwarded_env_var_prefixes:
+            if env_var.startswith(prefix):
+                return True
+
+        return False
+
+    def execute_command(self, command, shell=False):
+        """
+        Execute a command line subprocess.
+
+        :param command: String or sequence of strings of the command to execute
+                        with its arguments.
+        :param shell: If true, the command will be executed through the shell.
+        :return: A tuple with the (return code, stdout, stderr)
+        """
+        try:
+            import flame
+
+            if "execute_command" in dir(
+                flame
+            ) and sgtk.platform.current_engine().execute_hook_method(
+                "execute_command_hooks", "use_flame_execute_command"
+            ):
+
+                env_vars = []
+                for env_var in os.environ.items():
+                    if sgtk.platform.current_engine().execute_hook_method(
+                        "execute_command_hooks",
+                        "is_env_var_forwaded",
+                        env_var=env_var[0],
+                    ):
+                        env_vars.append("=".join(env_var))
+
+                if isinstance(command, list):
+                    command = " ".join(command)
+                if env_vars:
+                    command = "/usr/bin/env " + " ".join(env_vars) + " " + command
+
+                return flame.execute_command(
+                    command=command,
+                    blocking=True,
+                    shell=shell,
+                    capture_stdout=True,
+                    capture_stderr=True,
+                )
+        except ImportError:
+            pass
+        import subprocess
+
+        process = subprocess.Popen(
+            command if isinstance(command, list) else command.split(" "),
+            stdout=subprocess.PIPE,
+            shell=shell,
+            close_fds=True,
+        )
+        stdout, stderr = process.communicate()
+        stdout = stdout.decode("utf-8") if stdout else None
+        stderr = stderr.decode("utf-8") if stderr else None
+        rc = process.returncode
+        return rc, stdout, stderr

--- a/info.yml
+++ b/info.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 Shotgun Software Inc.
+# Copyright (c) 2021 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY
 #
@@ -33,6 +33,11 @@ configuration:
         type: hook
         default_value: "{self}/backburner_hooks.py"
         description: Contains the Backburner background job logic
+
+    execute_command_hooks:
+        type: hook
+        default_value: "{self}/execute_command.py"
+        description: Contains the logic for starting command line subprocess withing Flame process.
 
     flame_batch_publish_type:
         type: tank_type

--- a/python/tk_flame/wiretap.py
+++ b/python/tk_flame/wiretap.py
@@ -272,7 +272,7 @@ class WiretapHandler(object):
             else:
                 self._engine.log_debug("Project settings ui will be bypassed.")
             # create the project : Using the command line tool here instead of the python API because we need root privileges to set the group id.
-            import subprocess, os
+            import os
 
             project_create_cmd = [
                 os.path.join(self._engine.wiretap_tools_root, "wiretap_create_node"),
@@ -286,7 +286,7 @@ class WiretapHandler(object):
                 project_create_cmd.append("-g")
                 project_create_cmd.append(group_name)
 
-            subprocess.check_call(project_create_cmd)
+            self._engine.execute_command(project_create_cmd)
 
             # create project settings
 

--- a/python/tk_flame/wiretap.py
+++ b/python/tk_flame/wiretap.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 Shotgun Software Inc.
+# Copyright (c) 2021 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY
 #
@@ -286,7 +286,9 @@ class WiretapHandler(object):
                 project_create_cmd.append("-g")
                 project_create_cmd.append(group_name)
 
-            self._engine.execute_command(project_create_cmd)
+            self._engine.execute_hook_method(
+                "execute_command_hooks", "execute_command", command=project_create_cmd
+            )
 
             # create project settings
 


### PR DESCRIPTION
JIRA: FLME-53905

os.system() or subprocess calls in python will fork() the flame process to start new process. This will duplicate open resources before calling exec() and can lead to hangs depending on what Flame is doing before the fork.

In order to prevent that, use Flame python API execute_command() call, when available, that leverage the Autodesk Flame Multi-Purpose Daemon to start command lines instead of relying on python native way of starting process.