### PR TITLE
Fix selection of proper application path for version extraction [2]

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -191,10 +191,10 @@ class FlameLauncher(SoftwareLauncher):
                 "startup",
                 "app_launcher.py",
             )
-            python_exec_path = env["TOOLKIT_FLAME_PYTHON_BINARY"]
             args = "'%s' %s %s" % (launch_script, exec_path, args)
+            exec_path = env["TOOLKIT_FLAME_PYTHON_BINARY"]
 
-        return LaunchInformation(python_exec_path, args, env)
+        return LaunchInformation(exec_path, args, env)
 
     def scan_software(self):
         """


### PR DESCRIPTION
JIRA: FLME-59475

Follow-up on previous commit 97d5cb8b8bd562124e954e8c03c10b8c6b69750b
Reverse operation to keep an exec_path varible which is needed by one code path