### PR TITLE
Improve error handling when configuration has no media root path defined

### DIFF
--- a/hooks/tk-multi-loader2/flame_loader_actions.py
+++ b/hooks/tk-multi-loader2/flame_loader_actions.py
@@ -747,7 +747,7 @@ class FlameLoaderActions(HookBaseClass):
                 else:
                     self.parent.log_warning("Unknown attribute: %s" % attribute)
             except Exception as e:
-                self.parent.log_warning("Could nto set attribute %s to %s: %s" % (attribute, value, e))
+                self.parent.log_warning("Could not set attribute %s to %s: %s" % (attribute, value, e))
 
         # Connect the Write File node to the node
         flame.batch.connect_nodes(node, "Default", write_node, "Front")

--- a/hooks/tk-multi-loader2/flame_loader_actions.py
+++ b/hooks/tk-multi-loader2/flame_loader_actions.py
@@ -703,7 +703,6 @@ class FlameLoaderActions(HookBaseClass):
                 " or use template by setting env var SHOTGUN_FLAME_USE_TEMPLATE."
             )
 
-
         # Create a .batch file
         if self.use_template and self.setup_path_template:
             _, setup_path, _ = self._build_path_from_template(
@@ -747,7 +746,9 @@ class FlameLoaderActions(HookBaseClass):
                 else:
                     self.parent.log_warning("Unknown attribute: %s" % attribute)
             except Exception as e:
-                self.parent.log_warning("Could not set attribute %s to %s: %s" % (attribute, value, e))
+                self.parent.log_warning(
+                    "Could not set attribute %s to %s: %s" % (attribute, value, e)
+                )
 
         # Connect the Write File node to the node
         flame.batch.connect_nodes(node, "Default", write_node, "Front")

--- a/hooks/tk-multi-loader2/flame_loader_actions.py
+++ b/hooks/tk-multi-loader2/flame_loader_actions.py
@@ -696,6 +696,13 @@ class FlameLoaderActions(HookBaseClass):
                     if sgtk.platform.current_engine().is_version_less_than("2019.2"):
                         self.parent.log_warning("Absolute Open Clip Path not supported")
                         write_file_info["create_clip"] = False
+        else:
+            self.parent.log_warning(
+                "Media Path not defined. Either set in the config"
+                " media_path_root attribute, set env var SHOTGUN_FLAME_MEDIA_PATH_ROOT"
+                " or use template by setting env var SHOTGUN_FLAME_USE_TEMPLATE."
+            )
+
 
         # Create a .batch file
         if self.use_template and self.setup_path_template:
@@ -733,11 +740,14 @@ class FlameLoaderActions(HookBaseClass):
 
         # Param is a OrderedDict so the attributes are set in the right order
         for attribute, value in param.items():
-            if hasattr(write_node, attribute):
-                app.log_debug("Write File %s = %s" % (attribute, value))
-                setattr(write_node, attribute, value)
-            else:
-                self.parent.log_warning("Unknown attribute: %s" % attribute)
+            try:
+                if hasattr(write_node, attribute):
+                    app.log_debug("Write File %s = %s" % (attribute, value))
+                    setattr(write_node, attribute, value)
+                else:
+                    self.parent.log_warning("Unknown attribute: %s" % attribute)
+            except Exception as e:
+                self.parent.log_warning("Could nto set attribute %s to %s: %s" % (attribute, value, e))
 
         # Connect the Write File node to the node
         flame.batch.connect_nodes(node, "Default", write_node, "Front")


### PR DESCRIPTION
JIRA: FLME-61391
ShotGrid Loader: write file contains only the name, no associated file path

Give a warning with possible solutions when a config with no media root path has been defined.

In Zero-Config, the media_path_root attribute of the configuration is by definition not defined. The user should either define it or use one of the two env var SHOTGUN_FLAME_MEDIA_PATH_ROOT or SHOTGUN_FLAME_USE_TEMPLATE to provide a valid path.