### PR TITLE
Add support for Qt6/PySide6

### DIFF
--- a/python/tk_flame/ui/project_create_dialog.py
+++ b/python/tk_flame/ui/project_create_dialog.py
@@ -8,18 +8,15 @@
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
 
-try:
-    from tank.platform.qt.QtCore import *
-except ImportError:
-    from PySide2.QtCore import *
-try:
-    from tank.platform.qt.QtGui import *
-except ImportError:
-    from PySide2.QtGui import *
-try:
-    from tank.platform.qt.QtWidgets import *
-except ImportError:
-    from PySide2.QtWidgets import *
+from sgtk.platform.qt import QtCore
+for name, cls in QtCore.__dict__.items():
+    if isinstance(cls, type): globals()[name] = cls
+
+from sgtk.platform.qt import QtGui
+for name, cls in QtGui.__dict__.items():
+    if isinstance(cls, type): globals()[name] = cls
+
+
 
 from  . import resources_rc
 

--- a/python/tk_flame/ui/resources_rc.py
+++ b/python/tk_flame/ui/resources_rc.py
@@ -3,10 +3,7 @@
 # Created by: The Resource Compiler for Qt version 5.15.2
 # WARNING! All changes made in this file will be lost!
 
-try:
-    from tank.platform.qt import QtCore
-except ImportError:
-    from PySide2 import QtCore
+from sgtk.platform.qt import QtCore
 
 qt_resource_data = b"\
 \x00\x005\xe7\


### PR DESCRIPTION
DESCRIPTION

Replaced imports to get QtCore and QtGui from sgtk.platform.qt. sgtk.platform.qt does the job of abstacting from where QtCore/QtGui is coming from : PyQt4, PySide, PySide2, or PySide6 The only drawback is that you cannot do

from sgtk.platform.qt.QtGui import *

but just

from sgtk.platform.qt import QtGui

So to import all the QtGui classes for example, we need to do

from sgtk.platform.qt import QtGui
for name, cls in QtGui.__dict__.items():
    if isinstance(cls, type): globals()[name] = cls

Which will get all the classes of QtGui and put them all in the globals dictionary so that you can access the QtGui classes directly.

Also modified the build_resources.sh script:
- to change the imports accordingly
- to support Qt6
- to discard the QWidgets import as the sgtk.platform.qt put all these classes in the QtGui module