### PR TITLE
Remove description tag in project XML metadata.

### DIFF
--- a/python/tk_flame/wiretap.py
+++ b/python/tk_flame/wiretap.py
@@ -314,13 +314,6 @@ class WiretapHandler(object):
             # when making modifications.
 
             xml = "<Project>"
-
-            xml += (
-                "<Description>%s</Description>"
-                % "Created by Flow Production Tracking Flame Integration %s"
-                % self._engine.version
-            )
-
             xml += self._append_setting_to_xml(project_settings, "SetupDir")
             xml += self._append_setting_to_xml(project_settings, "FrameWidth")
             xml += self._append_setting_to_xml(project_settings, "FrameHeight")


### PR DESCRIPTION
JIRA: FLME-67362
Flow: Starting a project from Flow Desktop for the first time gives Error

The description tag was silently ignored before 2025.1 but is causing an error now.