### PR TITLE
Fix undefined variable

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -293,7 +293,7 @@ class FlameEngine(sgtk.platform.Engine):
                 "the filesystem permissions. As a fallback, logs will be "
                 "written to %s instead.",
                 std_log_file,
-                log_file,
+                self._log_file,
             )
 
     @property


### PR DESCRIPTION
This error was likely missed because in most cases the log file is writeable, so the logic of using the fallback file was unused.
If however, `std_log_file` was ready-only the missing variable would throw an error on attempting to log it, causing the engine setup to crash.