### PR TITLE
Cannot load setup from Flow when you have custom named batch Reels

### DIFF
--- a/hooks/tk-multi-loader2/flame_loader_actions.py
+++ b/hooks/tk-multi-loader2/flame_loader_actions.py
@@ -374,7 +374,7 @@ class FlameLoaderActions(HookBaseClass):
         :rtype: str
         """
 
-        return os.environ.get("SHOTGUN_FLAME_IMPORT_LOCATION", "Schematic Reel 1")
+        return os.environ.get("SHOTGUN_FLAME_IMPORT_LOCATION", flame.batch.reels[0].name.get_value())
 
     @property
     def want_write_file_node(self):


### PR DESCRIPTION
The default import destination reel could not be
"Schematic Reel 1" because we can now rename the default batch reels from the Flame preferences.  
Use directly the first reel instead for the default.

The user can still change it with the envvar SHOTGUN_FLAME_IMPORT_LOCATION

JIRA: FLME-70327